### PR TITLE
Change requests for MEMF_ANY to MEMF_FAST to be explicit.

### DIFF
--- a/ab3d2_source/hires.s
+++ b/ab3d2_source/hires.s
@@ -129,13 +129,13 @@ _start
 				ENDC
 
 				; allocate Level Data
-				move.l	#MEMF_ANY,d1
+				move.l	#MEMF_FAST,d1
 				move.l	#LEVELDATASize,d0
 				CALLEXEC AllocMem
 				move.l	d0,LEVELDATA
 
 				; allocate chunky render buffer in fastmem
-				move.l	#MEMF_ANY,d1
+				move.l	#MEMF_FAST,d1
 				move.l	#FASTBUFFERSize,d0
 				CALLEXEC AllocMem
 				move.l	d0,FASTBUFFERalloc
@@ -343,24 +343,24 @@ PLAYTHEGAME:
 				move.l	#_custom,a6
 				jsr		SETPLAYERS
 
-				move.l	#MEMF_ANY,TYPEOFMEM
+				move.l	#MEMF_FAST,TYPEOFMEM
 				move.l	#LLname,a0
 				jsr		LOADAFILE
 				move.l	d0,LINKS
 
-				move.l	#MEMF_ANY,TYPEOFMEM
+				move.l	#MEMF_FAST,TYPEOFMEM
 				move.l	#LLFname,a0
 				jsr		LOADAFILE
 				move.l	d0,FLYLINKS
 
 ; Get level memory.
 
-				move.l	#MEMF_ANY,d1
+				move.l	#MEMF_FAST,d1
 				move.l	#40000,d0
 				CALLEXEC AllocMem
 				move.l	d0,LEVELGRAPHICS
 
-				move.l	#MEMF_ANY,d1
+				move.l	#MEMF_FAST,d1
 				move.l	#40000,d0
 				CALLEXEC AllocMem
 				move.l	d0,LEVELCLIPS

--- a/ab3d2_source/newloadfromdisk.s
+++ b/ab3d2_source/newloadfromdisk.s
@@ -505,7 +505,7 @@ LOADOBS:
 				move.l	LINKFILE,a0
 				lea		ObjectGfxNames(a0),a0
 
-				move.l	#MEMF_ANY,TYPEOFMEM
+				move.l	#MEMF_FAST,TYPEOFMEM
 
 				move.l	#Objects,a1
 
@@ -604,7 +604,7 @@ LOAD_A_PALETTE
 
 				move.l	#2048,blocklen
 
-				move.l	#MEMF_ANY,d1
+				move.l	#MEMF_FAST,d1
 				move.l	blocklen,d0
 				CALLEXEC AllocMem
 				move.l	d0,blockstart
@@ -644,7 +644,7 @@ LOAD_AN_OBJ:
 
 				move.l	$7c(a5),blocklen
 
-				move.l	#MEMF_ANY,d1
+				move.l	#MEMF_FAST,d1
 				move.l	blocklen,d0
 				CALLEXEC AllocMem
 				move.l	d0,blockstart
@@ -728,7 +728,7 @@ oktoload:
 				adda.w	#64,a0
 				dbra	d7,LOADSAMPS
 
-				move.l	#MEMF_ANY,TYPEOFMEM
+				move.l	#MEMF_FAST,TYPEOFMEM
 
 				rts
 
@@ -819,7 +819,7 @@ LOADFLOOR
 				add.l	#FloorTileFilename,a0
 				move.l	#floortile,d0
 				move.l	#0,d1
-				move.l	#MEMF_ANY,TYPEOFMEM
+				move.l	#MEMF_FAST,TYPEOFMEM
 				jsr		QUEUEFILE
 ; move.l d0,floortile
 

--- a/ab3d2_source/wallchunk.s
+++ b/ab3d2_source/wallchunk.s
@@ -44,7 +44,7 @@ emptywalls:
 				move.l	#walltiles,a4
 				move.l	LINKFILE,a3
 				add.l	#WallGFXNames,a3
-				move.l	#MEMF_ANY,TYPEOFMEM
+				move.l	#MEMF_FAST,TYPEOFMEM
 
 loademin:
 				move.l	(a3),d0


### PR DESCRIPTION
In order to be more explicit about which memory we prefer, changes requests for MEMF_ANY to MEMF_FAST. MEMF_CHIP should only be used for things that genuinely need it.

Keeping PR draft status until I've had a chance to actually build it.