### PR TITLE
Candidate fix for Issue #9, with minor optimisations

### DIFF
--- a/ab3d2_source/hires.s
+++ b/ab3d2_source/hires.s
@@ -8698,11 +8698,16 @@ scaleprog:
 
 				; if the clipped left edge of the floor line is > 0,
 				; need  to inset the start of the floorspace coordinate accordingly
-				add.l	d6,d6
-				divs	#3,d6					; * 2/3 seems to be the FULLSCREEN multiplier?
-				ext.l	d6						; FIXME: why are we applying that here?
+				;add.l	d6,d6
+				;divs	#3,d6					; * 2/3 seems to be the FULLSCREEN multiplier?
+				;ext.l	d6						; FIXME: why are we applying that here?
+
 									; shouldn't that have been implicit when calulating the clipping stuff?
 									; but taking it away, doesn't work
+
+				; 0xABADCAFE quicker evaluation of 2/3 multiplier, 171/256 => 0.66796875
+				muls.l	#171,d6
+				asr.l	#8,d6
 
 				move.l	d1,a4					; save width * cos * scale
 				move.l	d2,a5					; save width * sin * scale
@@ -8737,8 +8742,14 @@ scaleprog:
 				; multiply floor space step ds/dx and dt/dx by Fullscreen multiplier
 				asr.l	#6,d1					; don't shift by 7, but 6
 				asr.l	#6,d2
-				divs.l	#3,d1					; to achieve * 2/3
-				divs.l	#3,d2
+;				divs.l	#3,d1					; to achieve * 2/3
+;				divs.l	#3,d2
+
+				; 0xABADCAFE quicker evaluation of 1/3 multiplier, 85/256 => 0.33203125
+				muls.l  #85,d1
+				muls.l  #85,d2
+				asr.l	#8,d1
+				asr.l	#8,d2
 
 				bra.s	doneallmult
 

--- a/ab3d2_source/hires.s
+++ b/ab3d2_source/hires.s
@@ -8706,8 +8706,13 @@ scaleprog:
 									; but taking it away, doesn't work
 
 				; 0xABADCAFE quicker evaluation of 2/3 multiplier, 171/256 => 0.66796875
-				muls.l	#171,d6
+				;muls.l	#171,d6
+				;asr.l	#8,d6
+
+				; 0xABADCAFE : Issue 9 - Try multiplier of 6/10, using 10 bit precision
+				muls.l  #614,d6
 				asr.l	#8,d6
+				asr.l	#2,d6
 
 				move.l	d1,a4					; save width * cos * scale
 				move.l	d2,a5					; save width * sin * scale
@@ -8746,10 +8751,20 @@ scaleprog:
 ;				divs.l	#3,d2
 
 				; 0xABADCAFE quicker evaluation of 1/3 multiplier, 85/256 => 0.33203125
-				muls.l  #85,d1
-				muls.l  #85,d2
-				asr.l	#8,d1
-				asr.l	#8,d2
+				;muls.l  #85,d1
+				;muls.l  #85,d2
+				;muls.l  #77,d1
+				;muls.l  #77,d2
+				;asr.l	#8,d1
+				;asr.l	#8,d2
+
+				; 0xABADCAFE - Issue #9 - Use 3/10 multiplier, 10 bits precision
+				muls.l  #307,d1
+				muls.l  #307,d2
+				asr.l   #8,d1
+				asr.l   #8,d2
+				asr.l   #2,d1
+				asr.l   #2,d2
 
 				bra.s	doneallmult
 

--- a/ab3d2_source/objdrawhires.s
+++ b/ab3d2_source/objdrawhires.s
@@ -2208,7 +2208,8 @@ MYacross:
 				sub.w	d3,d4
 				swap	d3
 				swap	d4
-				divs.l	#8,d4
+;				divs.l	#8,d4 ; 0xABADCAFE delete after testing
+				asr.l	#3,d4
 				moveq	#7,d2
 				moveq	#3*16,d5
 .down:
@@ -2241,8 +2242,9 @@ TOPPART:
 				sub.w	d3,d4
 				swap	d3
 				swap	d4
-				divs.l	#8,d4
-				asr.l	#1,d4					; halfway
+;				divs.l	#8,d4 ; 0xABADCAFE delete after testing
+;				asr.l	#1,d4					; halfway
+				asr.l	#4,d4
 				moveq	#3,d2
 				moveq	#3*16,d5
 .down:
@@ -2275,8 +2277,9 @@ BOTPART:
 				sub.w	d3,d4
 				swap	d3
 				swap	d4
-				divs.l	#8,d4
-				asr.l	#1,d4					; halfway
+;				divs.l	#8,d4 ; 0xABADCAFE delete after testing
+;				asr.l	#1,d4					; halfway
+				asr.l	#4,d4
 				moveq	#3,d2
 				move.w	#11*16,d5
 .down:


### PR DESCRIPTION
While examining issue #9 I noticed a few places where fixed integer division could be optimised:
- In a couple of places in the animation logic, long signed divide by 8 was used - replaced with arithmetic shift right
- In some of transformation logic involved in floor and ceiling rendering, long signed division by three has been replaced with an approximation based 85/256 (multiplication requiring fewer cycles than division)

Changes tested in 2/3 and fullscreen mode without any new regressions.

Applied suggested fixes for Issue #9 - changing the multiplier from 2/3 to 6/10
- Does not completely eliminate the swimming but is much less noticeable and does not systematically drift to the right.
- Does appear to move slightly with respect to the player bob motion and rotation.