### PR TITLE
Reformatting/structures

### DIFF
--- a/ab3d2_source/cd32joy.s
+++ b/ab3d2_source/cd32joy.s
@@ -162,7 +162,7 @@ _ReadJoy1
 				st		.heldlast
 
 				moveq	#0,d0
-				move.b	Plr1_GunSelected_w,d0
+				move.b	Plr1_GunSelected_b,d0
 				move.l	#PLAYERONEGUNS,a0
 
 
@@ -175,7 +175,7 @@ _ReadJoy1
 				tst.w	(a0,d0.w*2)
 				beq.s	.findnext
 
-				move.b	d0,Plr1_GunSelected_w
+				move.b	d0,Plr1_GunSelected_b
 				jsr		SHOWPLR1GUNNAME
 
 				bra		.nonextweap
@@ -348,7 +348,7 @@ _ReadJoy2
 				st		.heldlast
 
 				moveq	#0,d0
-				move.b	PLR2_GunSelected,d0
+				move.b	Plr2_GunSelected_b,d0
 				move.l	#PLAYERTWOGUNS,a0
 
 .findnext
@@ -360,7 +360,7 @@ _ReadJoy2
 				tst.w	(a0,d0.w*2)
 				beq.s	.findnext
 
-				move.b	d0,PLR2_GunSelected
+				move.b	d0,Plr2_GunSelected_b
 				jsr		SHOWPLR2GUNNAME
 
 				bra		.nonextweap

--- a/ab3d2_source/cd32joy.s
+++ b/ab3d2_source/cd32joy.s
@@ -162,7 +162,7 @@ _ReadJoy1
 				st		.heldlast
 
 				moveq	#0,d0
-				move.b	PLR1_GunSelected,d0
+				move.b	Plr1_GunSelected_w,d0
 				move.l	#PLAYERONEGUNS,a0
 
 
@@ -175,7 +175,7 @@ _ReadJoy1
 				tst.w	(a0,d0.w*2)
 				beq.s	.findnext
 
-				move.b	d0,PLR1_GunSelected
+				move.b	d0,Plr1_GunSelected_w
 				jsr		SHOWPLR1GUNNAME
 
 				bra		.nonextweap

--- a/ab3d2_source/controlloop.s
+++ b/ab3d2_source/controlloop.s
@@ -239,11 +239,11 @@ DONEMENU:
 
 				clr.b	FINISHEDLEVEL
 
-				move.w	#0,PLR1s_angpos
+				move.w	#0,Plr1_AltAngPos_w
 				move.w	#0,PLR2s_angpos
-				move.w	#0,PLR1_angpos
+				move.w	#0,Plr1_AngPos_w
 				move.w	#0,PLR2_angpos
-				move.b	#0,PLR1_GunSelected
+				move.b	#0,Plr1_GunSelected_w
 				move.b	#0,PLR2_GunSelected
 
 **************************8
@@ -1012,7 +1012,7 @@ TWOPLAYER:
 				jsr		AmmoBar
 				move.w	#0,OldAmmo
 
-				move.b	#0,PLR1_GunSelected
+				move.b	#0,Plr1_GunSelected_w
 
 				move.b	#0,PLR2_GunSelected
 				rts

--- a/ab3d2_source/controlloop.s
+++ b/ab3d2_source/controlloop.s
@@ -239,12 +239,12 @@ DONEMENU:
 
 				clr.b	FINISHEDLEVEL
 
-				move.w	#0,Plr1_AltAngPos_w
-				move.w	#0,PLR2s_angpos
+				move.w	#0,Plr1_SnapAngPos_w
+				move.w	#0,Plr2_SnapAngPos_w
 				move.w	#0,Plr1_AngPos_w
-				move.w	#0,PLR2_angpos
-				move.b	#0,Plr1_GunSelected_w
-				move.b	#0,PLR2_GunSelected
+				move.w	#0,Plr2_AngPos_w
+				move.b	#0,Plr1_GunSelected_b
+				move.b	#0,Plr2_GunSelected_b
 
 **************************8
 				clr.b	NASTY
@@ -1012,9 +1012,9 @@ TWOPLAYER:
 				jsr		AmmoBar
 				move.w	#0,OldAmmo
 
-				move.b	#0,Plr1_GunSelected_w
+				move.b	#0,Plr1_GunSelected_b
 
-				move.b	#0,PLR2_GunSelected
+				move.b	#0,Plr2_GunSelected_b
 				rts
 
 newdum:

--- a/ab3d2_source/fall.s
+++ b/ab3d2_source/fall.s
@@ -1,8 +1,8 @@
 
 PLR1_fall
-				move.l	Plr1_AltTYOff_l,d0
-				move.l	Plr1_AltYOff_l,d1
-				move.l	Plr1_AltYVel_l,d2
+				move.l	Plr1_SnapTYOff_l,d0
+				move.l	Plr1_SnapYOff_l,d1
+				move.l	Plr1_SnapYVel_l,d2
 
 				cmp.l	d1,d0
 				bgt		.aboveground
@@ -194,8 +194,8 @@ CARRYON:
 				moveq	#0,d2
 .okroof:
 
-				move.l	d2,Plr1_AltYVel_l
-				move.l	d1,Plr1_AltYOff_l
+				move.l	d2,Plr1_SnapYVel_l
+				move.l	d1,Plr1_SnapYOff_l
 
 				rts
 
@@ -213,7 +213,7 @@ ARSE:
 				sub.l	d2,d0
 				blt.s	.pastitall
 				move.l	#0,d2
-				move.l	Plr1_AltTYOff_l,d1
+				move.l	Plr1_SnapTYOff_l,d1
 				bra.s	.pastitall
 
 .aboveground:
@@ -234,15 +234,15 @@ ARSE:
 
 .pastitall:
 
-				move.l	d2,Plr1_AltYVel_l
-				move.l	d1,Plr1_AltYOff_l
+				move.l	d2,Plr1_SnapYVel_l
+				move.l	d1,Plr1_SnapYOff_l
 
 				move.l	#KeyMap,a5
 				tst.b	$1d(a5)
 				beq.s	nothrust2
 				tst.b	CANJUMP
 				beq.s	nothrust2
-				move.l	JUMPSPD,Plr1_AltYVel_l
+				move.l	JUMPSPD,Plr1_SnapYVel_l
 nothrust2:
 
 				move.l	Plr1_RoomPtr_l,a5
@@ -252,10 +252,10 @@ nothrust2:
 				move.l	ZoneT_UpperRoof_l(a5),d0
 .usebottom:
 
-				move.l	Plr1_AltYOff_l,d1
-				move.l	Plr1_AltYVel_l,d2
+				move.l	Plr1_SnapYOff_l,d1
+				move.l	Plr1_SnapYVel_l,d2
 
-				sub.l	Plr1_AltHeight_l,d1
+				sub.l	Plr1_SnapHeight_l,d1
 				sub.l	#10*256,d1
 				cmp.l	d1,d0
 				blt.s	.notinroof
@@ -265,17 +265,17 @@ nothrust2:
 				moveq	#0,d2
 .notinroof
 				add.l	#10*256,d1
-				add.l	Plr1_AltHeight_l,d1
-				move.l	d1,Plr1_AltYOff_l
+				add.l	Plr1_SnapHeight_l,d1
+				move.l	d1,Plr1_SnapYOff_l
 
-				move.l	d2,Plr1_AltYVel_l
+				move.l	d2,Plr1_SnapYVel_l
 
 				rts
 
 PLR2_fall
-				move.l	PLR2s_tyoff,d0
-				move.l	PLR2s_yoff,d1
-				move.l	PLR2s_yvel,d2
+				move.l	Plr2_SnapTYOff_l,d0
+				move.l	Plr2_SnapYOff_l,d1
+				move.l	Plr2_SnapYVel_l,d2
 
 				cmp.l	d1,d0
 				bgt		.aboveground
@@ -324,7 +324,7 @@ PLR2_fall
 
 				move.l	#-1024,JUMPSPD
 
-				move.l	PLR2_Roompt,a2
+				move.l	Plr2_RoomPtr_l,a2
 				move.l	ZoneT_Water_l(a2),d0
 				cmp.l	d0,d1
 				blt.s	.notinwater
@@ -409,7 +409,7 @@ PLR2_fall
 
 				add.w	#1,DAMAGEWHENHIT
 
-				move.l	PLR2_Roompt,a2
+				move.l	Plr2_RoomPtr_l,a2
 				move.l	ZoneT_Water_l(a2),d0
 				cmp.l	d0,d1
 				blt.s	CARRYON2
@@ -440,9 +440,9 @@ PLR2_fall
 
 CARRYON2:
 
-				move.l	PLR2_Roompt,a2
+				move.l	Plr2_RoomPtr_l,a2
 				move.l	ZoneT_Roof_l(a2),d3
-				tst.b	PLR2_StoodInTop
+				tst.b	Plr2_StoodInTop_b
 				beq.s	.okbot
 				move.l	ZoneT_UpperRoof_l(a2),d3
 .okbot:
@@ -456,8 +456,8 @@ CARRYON2:
 				moveq	#0,d2
 .okroof:
 
-				move.l	d2,PLR2s_yvel
-				move.l	d1,PLR2s_yoff
+				move.l	d2,Plr2_SnapYVel_l
+				move.l	d1,Plr2_SnapYOff_l
 
 				rts
 

--- a/ab3d2_source/fall.s
+++ b/ab3d2_source/fall.s
@@ -1,8 +1,8 @@
 
 PLR1_fall
-				move.l	PLR1s_tyoff,d0
-				move.l	PLR1s_yoff,d1
-				move.l	PLR1s_yvel,d2
+				move.l	Plr1_AltTYOff_l,d0
+				move.l	Plr1_AltYOff_l,d1
+				move.l	Plr1_AltYVel_l,d2
 
 				cmp.l	d1,d0
 				bgt		.aboveground
@@ -23,7 +23,7 @@ PLR1_fall
 				bra		CARRYON
 
 .onground:
-				move.w	PLR1_FloorSpd,d2
+				move.w	Plr1_FloorSpd_l,d2
 				ext.l	d2
 				asl.l	#6,d2
 
@@ -39,9 +39,9 @@ PLR1_fall
 
 				move.w	ADDTOBOBBLE,d3
 				move.w	d3,d4
-				add.w	PLR1_bobble,d3
+				add.w	Plr1_Bobble_w,d3
 				and.w	#8190,d3
-				move.w	d3,PLR1_bobble
+				move.w	d3,Plr1_Bobble_w
 				add.w	PLR1_clumptime,d4
 				move.w	d4,d3
 				and.w	#4095,d4
@@ -56,7 +56,7 @@ PLR1_fall
 
 				move.l	#-1024,JUMPSPD
 
-				move.l	PLR1_Roompt,a2
+				move.l	Plr1_RoomPtr_l,a2
 				move.l	ZoneT_Water_l(a2),d0
 				cmp.l	d0,d1
 				blt.s	.notinwater
@@ -112,9 +112,9 @@ PLR1_fall
 				add.l	JUMPSPD,d2
 				move.w	#0,DAMAGEWHENHIT
 				move.w	#40,d3
-				add.w	PLR1_bobble,d3
+				add.w	Plr1_Bobble_w,d3
 				and.w	#8190,d3
-				move.w	d3,PLR1_bobble
+				move.w	d3,Plr1_Bobble_w
 .nofly:
 
 				move.l	d0,d3
@@ -141,7 +141,7 @@ PLR1_fall
 .nodam2
 				move.w	#0,DAMAGEWHENHIT
 
-				move.w	PLR1_FloorSpd,d2
+				move.w	Plr1_FloorSpd_l,d2
 				ext.l	d2
 				asl.l	#6,d2
 
@@ -151,7 +151,7 @@ PLR1_fall
 				add.l	#64,d2
 				add.w	#1,DAMAGEWHENHIT
 
-				move.l	PLR1_Roompt,a2
+				move.l	Plr1_RoomPtr_l,a2
 				move.l	ZoneT_Water_l(a2),d0
 				cmp.l	d0,d1
 				blt.s	CARRYON
@@ -178,9 +178,9 @@ PLR1_fall
 				move.l	#512,d2					; reached terminal velocity.
 CARRYON:
 
-				move.l	PLR1_Roompt,a2
+				move.l	Plr1_RoomPtr_l,a2
 				move.l	ZoneT_Roof_l(a2),d3
-				tst.b	PLR1_StoodInTop
+				tst.b	Plr1_StoodInTop_b
 				beq.s	.okbot
 				move.l	ZoneT_UpperRoof_l(a2),d3
 .okbot:
@@ -194,8 +194,8 @@ CARRYON:
 				moveq	#0,d2
 .okroof:
 
-				move.l	d2,PLR1s_yvel
-				move.l	d1,PLR1s_yoff
+				move.l	d2,Plr1_AltYVel_l
+				move.l	d1,Plr1_AltYOff_l
 
 				rts
 
@@ -213,7 +213,7 @@ ARSE:
 				sub.l	d2,d0
 				blt.s	.pastitall
 				move.l	#0,d2
-				move.l	PLR1s_tyoff,d1
+				move.l	Plr1_AltTYOff_l,d1
 				bra.s	.pastitall
 
 .aboveground:
@@ -222,7 +222,7 @@ ARSE:
 
 				move.l	#-1024,JUMPSPD
 
-				move.l	PLR1_Roompt,a2
+				move.l	Plr1_RoomPtr_l,a2
 				move.l	ZoneT_Water_l(a2),d0
 				cmp.l	d0,d1
 				blt.s	.pastitall
@@ -234,28 +234,28 @@ ARSE:
 
 .pastitall:
 
-				move.l	d2,PLR1s_yvel
-				move.l	d1,PLR1s_yoff
+				move.l	d2,Plr1_AltYVel_l
+				move.l	d1,Plr1_AltYOff_l
 
 				move.l	#KeyMap,a5
 				tst.b	$1d(a5)
 				beq.s	nothrust2
 				tst.b	CANJUMP
 				beq.s	nothrust2
-				move.l	JUMPSPD,PLR1s_yvel
+				move.l	JUMPSPD,Plr1_AltYVel_l
 nothrust2:
 
-				move.l	PLR1_Roompt,a5
+				move.l	Plr1_RoomPtr_l,a5
 				move.l	ZoneT_Roof_l(a5),d0
-				tst.b	PLR1_StoodInTop
+				tst.b	Plr1_StoodInTop_b
 				beq.s	.usebottom
 				move.l	ZoneT_UpperRoof_l(a5),d0
 .usebottom:
 
-				move.l	PLR1s_yoff,d1
-				move.l	PLR1s_yvel,d2
+				move.l	Plr1_AltYOff_l,d1
+				move.l	Plr1_AltYVel_l,d2
 
-				sub.l	PLR1s_height,d1
+				sub.l	Plr1_AltHeight_l,d1
 				sub.l	#10*256,d1
 				cmp.l	d1,d0
 				blt.s	.notinroof
@@ -265,10 +265,10 @@ nothrust2:
 				moveq	#0,d2
 .notinroof
 				add.l	#10*256,d1
-				add.l	PLR1s_height,d1
-				move.l	d1,PLR1s_yoff
+				add.l	Plr1_AltHeight_l,d1
+				move.l	d1,Plr1_AltYOff_l
 
-				move.l	d2,PLR1s_yvel
+				move.l	d2,Plr1_AltYVel_l
 
 				rts
 
@@ -308,9 +308,9 @@ PLR2_fall
 
 				move.w	ADDTOBOBBLE,d3
 				move.w	d3,d4
-				add.w	PLR2_bobble,d3
+				add.w	Plr2_Bobble_w,d3
 				and.w	#8190,d3
-				move.w	d3,PLR2_bobble
+				move.w	d3,Plr2_Bobble_w
 				add.w	PLR2_clumptime,d4
 				move.w	d4,d3
 				and.w	#4095,d4
@@ -381,9 +381,9 @@ PLR2_fall
 				move.w	#0,DAMAGEWHENHIT
 				sub.w	#1,PLAYERTWOFUEL
 				move.w	#40,d3
-				add.w	PLR2_bobble,d3
+				add.w	Plr2_Bobble_w,d3
 				and.w	#8190,d3
-				move.w	d3,PLR2_bobble
+				move.w	d3,Plr2_Bobble_w
 
 .nofly:
 

--- a/ab3d2_source/fall.s
+++ b/ab3d2_source/fall.s
@@ -23,7 +23,7 @@ PLR1_fall
 				bra		CARRYON
 
 .onground:
-				move.w	Plr1_FloorSpd_l,d2
+				move.w	Plr1_FloorSpd_w,d2
 				ext.l	d2
 				asl.l	#6,d2
 
@@ -141,7 +141,7 @@ PLR1_fall
 .nodam2
 				move.w	#0,DAMAGEWHENHIT
 
-				move.w	Plr1_FloorSpd_l,d2
+				move.w	Plr1_FloorSpd_w,d2
 				ext.l	d2
 				asl.l	#6,d2
 

--- a/ab3d2_source/hires.s
+++ b/ab3d2_source/hires.s
@@ -61,7 +61,7 @@ _start
 				movem.l	d1-a6,-(sp)
 **************************************************************************************
 ;ich bin hack  -----  invert FULLSCRTEMP to start game in fullsreen if cpu is 68040 AL
-				;movem.l	d0-d1/a0,-(a7)	
+				;movem.l	d0-d1/a0,-(a7)
 				move.l	4.w,a0
 				move.b	$129(a0),d0
 				move.l	#68040,d1	;68040
@@ -118,7 +118,7 @@ _start
 		move.l	timerrequest+IO_DEVICE,timerbase
 		move.l	d0,timerflag
 		;bne	error_exit
-		
+
 				IFEQ	CD32VER
 				lea		KEYInt(pc),a1
 				moveq	#INTB_PORTS,d0
@@ -127,23 +127,23 @@ _start
 
 				; init default control method
 				IFNE	CD32VER
-				clr.b	PLR1KEYS
-				clr.b	PLR1PATH
-				clr.b	PLR1MOUSE
-				st		PLR1JOY
-				clr.b	PLR2KEYS
-				clr.b	PLR2PATH
-				clr.b	PLR2MOUSE
-				st		PLR2JOY
+				clr.b	Plr1_Keys_b
+				clr.b	Plr1_Path_b
+				clr.b	Plr1_Mouse_b
+				st		Plr1_Joystick_b
+				clr.b	Plr2_Keys_b
+				clr.b	Plr2_Path_b
+				clr.b	Plr2_Mouse_b
+				st		Plr2_Joystick_b
 				ELSE
-				clr.b	PLR1KEYS
-				clr.b	PLR1PATH
-				st		PLR1MOUSE
-				clr.b	PLR1JOY
-				clr.b	PLR2KEYS
-				clr.b	PLR2PATH
-				st		PLR2MOUSE
-				clr.b	PLR2JOY
+				clr.b	Plr1_Keys_b
+				clr.b	Plr1_Path_b
+				st		Plr1_Mouse_b
+				clr.b	Plr1_Joystick_b
+				clr.b	Plr2_Keys_b
+				clr.b	Plr2_Path_b
+				st		Plr2_Mouse_b
+				clr.b	Plr2_Joystick_b
 				ENDC
 
 				; allocate chunky render buffer in fastmem
@@ -592,21 +592,21 @@ noclips:
 ;nkb:
 ; cmp.b #'m',Prefsfile
 ; bne.s nmc
-; clr.b PLR1KEYS
-; clr.b PLR1PATH
-; st PLR1MOUSE
-; clr.b PLR1JOY
+; clr.b Plr1_Keys_b
+; clr.b Plr1_Path_b
+; st Plr1_Mouse_b
+; clr.b Plr1_Joystick_b
 ;nmc:
 ; cmp.b #'j',Prefsfile
 ; bne.s njc
-; clr.b PLR1KEYS
-; clr.b PLR1PATH
-; clr.b PLR1MOUSE
-; st PLR1JOY
+; clr.b Plr1_Keys_b
+; clr.b Plr1_Path_b
+; clr.b Plr1_Mouse_b
+; st Plr1_Joystick_b
 ;njc:
 
-				clr.b	PLR1_StoodInTop
-				move.l	#playerheight,PLR1s_height
+				clr.b	Plr1_StoodInTop_b
+				move.l	#playerheight,Plr1_AltHeight_l
 
 				move.l	#empty,pos1LEFT
 				move.l	#empty,pos2LEFT
@@ -744,8 +744,8 @@ scaledownlop:
 
 				move.l	SampleList+6*8,pos0LEFT
 				move.l	SampleList+6*8+4,Samp0endLEFT
-				move.l	#playerheight,PLR1s_targheight
-				move.l	#playerheight,PLR1s_height
+				move.l	#playerheight,Plr1_AltTargHeight_l
+				move.l	#playerheight,Plr1_AltHeight_l
 				move.l	#playerheight,PLR2s_targheight
 				move.l	#playerheight,PLR2s_height
 
@@ -969,15 +969,15 @@ clrmessbuff:
 				move.w	#0,EntT_ImpactY_w(a1)
 				move.w	#0,EntT_ImpactZ_w(a1)
 
-				move.l	#0,PLR1s_xspdval
-				move.l	#0,PLR1s_zspdval
-				move.l	#0,PLR1s_yvel
+				move.l	#0,Plr1_AltXSpdVal_l
+				move.l	#0,Plr1_AltZSpdVal_l
+				move.l	#0,Plr1_AltYVel_l
 				move.l	#0,PLR2s_xspdval
 				move.l	#0,PLR2s_zspdval
 				move.l	#0,PLR2s_yvel
-				move.l	#0,PLR1_xspdval
-				move.l	#0,PLR1_zspdval
-				move.l	#0,PLR1_yvel
+				move.l	#0,Plr1_XSpdVal_l
+				move.l	#0,Plr1_ZSpdVal_l
+				move.l	#0,Plr1_YVel_l
 				move.l	#0,PLR2_xspdval
 				move.l	#0,PLR2_zspdval
 				move.l	#0,PLR2_yvel
@@ -1064,7 +1064,7 @@ lop:
 				move.b	AlienT_SplatType_w+1(a6),d0
 				move.b	d0,TypeOfSplat
 
-				move.l	PLR1_Roompt,a1
+				move.l	Plr1_RoomPtr_l,a1
 				move.w	(a1),12(a0)
 				move.w	p1_xoff,newx
 				move.w	p1_zoff,newz
@@ -1139,7 +1139,7 @@ lop:
 
 .waitrel:
 
-				tst.b	PLR1JOY
+				tst.b	Plr1_Joystick_b
 				beq.s	.NOJOY
 				jsr		_ReadJoy1
 .NOJOY
@@ -1180,12 +1180,12 @@ nofadedownhc:
 
 				cmp.b	#'s',mors
 				beq.s	.RE2
-				tst.b	PLR1JOY
+				tst.b	Plr1_Joystick_b
 				beq.s	.NOJOY
 				jsr		_ReadJoy1
 				bra		.RE1
 .RE2:
-				tst.b	PLR2JOY
+				tst.b	Plr2_Joystick_b
 				beq.s	.NOJOY
 				jsr		_ReadJoy2
 .RE1
@@ -1218,7 +1218,7 @@ nofadedownhc:
 				bra.s	.waitvbl
 .skipWaitTOF
 				move.l	d3,VBLCOUNTLAST
-				
+
 ; Swap screen bitmaps
 				move.l	SCRNDRAWPT,d0
 				move.l	SCRNSHOWPT,SCRNDRAWPT
@@ -1234,7 +1234,7 @@ nofadedownhc:
 ;				move.w	#$1,intreq(a6)
 
 ; move.l #PLR1_GunData,GunData
-				move.b	PLR1_GunSelected,GunSelected
+				move.b	Plr1_GunSelected_w,GunSelected
 				bra		waitmaster
 
 nowaitslave:
@@ -1303,8 +1303,8 @@ okwat:
 				add.l	#1,wateroff
 				and.l	#$3fff3fff,wateroff
 
-				move.l	PLR1_xoff,OLDX1
-				move.l	PLR1_zoff,OLDZ1
+				move.l	Plr1_XOff_l,OLDX1
+				move.l	Plr1_ZOff_l,OLDZ1
 				move.l	PLR2_xoff,OLDX2
 				move.l	PLR2_zoff,OLDZ2
 
@@ -1358,7 +1358,7 @@ okwat:
 ;				beq.s	.nocheat
 ;				sub.w	#1,CHEATNUM
 ;				move.l	#CHEATFRAME,a4
-;				move.w	#127,PLR1_energy
+;				move.w	#127,Plr1_Energy_w
 ;				jsr		EnergyBar
 ;.nocheat
 ;
@@ -1369,23 +1369,23 @@ okwat:
 **********************************************
 **********************************************
 
-				move.l	PLR1s_xoff,p1_xoff
-				move.l	PLR1s_zoff,p1_zoff
-				move.l	PLR1s_yoff,p1_yoff
-				move.l	PLR1s_height,p1_height
-				move.w	PLR1s_angpos,p1_angpos
-				move.w	PLR1_bobble,p1_bobble
+				move.l	Plr1_AltXOff_l,p1_xoff
+				move.l	Plr1_AltZOff_l,p1_zoff
+				move.l	Plr1_AltYOff_l,p1_yoff
+				move.l	Plr1_AltHeight_l,p1_height
+				move.w	Plr1_AltAngPos_w,p1_angpos
+				move.w	Plr1_Bobble_w,p1_bobble
 				move.b	PLR1_clicked,p1_clicked
 				move.b	PLR1_fire,p1_fire
 				clr.b	PLR1_clicked
 				move.b	PLR1_SPCTAP,p1_spctap
 				clr.b	PLR1_SPCTAP
 				move.b	PLR1_Ducked,p1_ducked
-				move.b	PLR1_GunSelected,p1_gunselected
+				move.b	Plr1_GunSelected_w,p1_gunselected
 
 				bsr		PLR1_Control
 
-				move.l	PLR1_Roompt,a0
+				move.l	Plr1_RoomPtr_l,a0
 				move.l	ZoneT_Roof_l(a0),SplitHeight
 				move.w	p1_xoff,THISPLRxoff
 				move.w	p1_zoff,THISPLRzoff
@@ -1431,19 +1431,19 @@ NotOnePlayer:
 .okframe:
 				move.w	#0,FramesToDraw
 
-				move.l	PLR1s_xoff,p1_xoff
-				move.l	PLR1s_zoff,p1_zoff
-				move.l	PLR1s_yoff,p1_yoff
-				move.l	PLR1s_height,p1_height
-				move.w	PLR1s_angpos,p1_angpos
-				move.w	PLR1_bobble,p1_bobble
+				move.l	Plr1_AltXOff_l,p1_xoff
+				move.l	Plr1_AltZOff_l,p1_zoff
+				move.l	Plr1_AltYOff_l,p1_yoff
+				move.l	Plr1_AltHeight_l,p1_height
+				move.w	Plr1_AltAngPos_w,p1_angpos
+				move.w	Plr1_Bobble_w,p1_bobble
 				move.b	PLR1_clicked,p1_clicked
 				clr.b	PLR1_clicked
 				move.b	PLR1_fire,p1_fire
 				move.b	PLR1_SPCTAP,p1_spctap
 				clr.b	PLR1_SPCTAP
 				move.b	PLR1_Ducked,p1_ducked
-				move.b	PLR1_GunSelected,p1_gunselected
+				move.b	Plr1_GunSelected_w,p1_gunselected
 
 				move.l	PLR1_AIMSPD,d0
 				jsr		SENDFIRST
@@ -1517,7 +1517,7 @@ NotOnePlayer:
 
 				bsr		PLR1_Control
 				bsr		PLR2_Control
-				move.l	PLR1_Roompt,a0
+				move.l	Plr1_RoomPtr_l,a0
 				move.l	ZoneT_Roof_l(a0),SplitHeight
 				move.w	p1_xoff,THISPLRxoff
 				move.w	p1_zoff,THISPLRzoff
@@ -1559,7 +1559,7 @@ ASlaveShouldWaitOnHisMaster:
 				move.l	PLR2s_yoff,p2_yoff
 				move.l	PLR2s_height,p2_height
 				move.w	PLR2s_angpos,p2_angpos
-				move.w	PLR2_bobble,p2_bobble
+				move.w	Plr2_Bobble_w,p2_bobble
 				move.b	PLR2_clicked,p2_clicked
 				clr.b	PLR2_clicked
 				move.b	PLR2_fire,p2_fire
@@ -1655,8 +1655,8 @@ donetalking:
 				move.l	a0,a5
 				cmp.b	#'s',mors
 				beq.s	doallz
-				move.l	PLR1_ListOfGraphRooms,a0
-; move.l PLR1_PointsToRotatePtr,a5
+				move.l	Plr1_ListOfGraphRoomsPtr_l,a0
+; move.l Plr1_PointsToRotatePtr_l,a5
 				move.l	a0,a5
 doallz
 				move.w	(a0),d0
@@ -1753,7 +1753,7 @@ allinzone:
 
 whythehell:
 
-				move.l	PLR1_Roompt,a0
+				move.l	Plr1_RoomPtr_l,a0
 				move.l	#CurrentPointBrights,a1
 				move.l	ZoneBorderPts,a2
 				move.w	(a0),d0
@@ -1781,12 +1781,12 @@ findaverage:
 				ext.l	d1
 				divs	d0,d1
 				sub.w	#300,d1
-				move.w	d1,PLR1_RoomBright
+				move.w	d1,Plr1_RoomBright_w
 
 				cmp.b	#'n',mors
 				beq		nosee
 
-				move.l	PLR1_Roompt,FromRoom
+				move.l	Plr1_RoomPtr_l,FromRoom
 				move.l	PLR2_Roompt,ToRoom
 				move.w	p1_xoff,Viewerx
 				move.w	p1_zoff,Viewerz
@@ -1798,7 +1798,7 @@ findaverage:
 				move.l	p2_yoff,d0
 				asr.l	#7,d0
 				move.w	d0,Targety
-				move.b	PLR1_StoodInTop,ViewerTop
+				move.b	Plr1_StoodInTop_b,ViewerTop
 				move.b	PLR2_StoodInTop,TargetTop
 				jsr		CanItBeSeen
 
@@ -1848,11 +1848,11 @@ okstillheld2:
 ***** CHECKING LIGHT *********
 
 ; move.w #-20,d0
-; move.w PLR1_xoff,d1
-; move.w PLR1_zoff,d2
-; move.l PLR1_Roompt,a0
+; move.w Plr1_XOff_l,d1
+; move.w Plr1_ZOff_l,d2
+; move.l Plr1_RoomPtr_l,a0
 ; move.w (a0),d3
-; move.w PLR1_angpos,d4
+; move.w Plr1_AngPos_w,d4
 ;
 ; jsr BRIGHTENPOINTSANGLE
 
@@ -1873,7 +1873,7 @@ okstillheld2:
 				moveq	#1,d1
 noze:
 
-				move.w	PLR1_xoff,d0
+				move.w	Plr1_XOff_l,d0
 				sub.w	OLDX1,d0
 				asl.w	#4,d0
 				ext.l	d0
@@ -1885,7 +1885,7 @@ noze:
 				ext.l	d0
 				divs	d1,d0
 				move.w	d0,XDIFF2
-				move.w	PLR1_zoff,d0
+				move.w	Plr1_ZOff_l,d0
 				sub.w	OLDZ1,d0
 				asl.w	#4,d0
 				ext.l	d0
@@ -1913,18 +1913,18 @@ IWasPlayer1:
 
 				move.w	#0,scaleval
 
-				move.l	PLR1_xoff,xoff
-				move.l	PLR1_yoff,yoff
-				move.l	PLR1_zoff,zoff
-				move.w	PLR1_angpos,angpos
-				move.w	PLR1_cosval,cosval
-				move.w	PLR1_sinval,sinval
+				move.l	Plr1_XOff_l,xoff
+				move.l	Plr1_YOff_l,yoff
+				move.l	Plr1_ZOff_l,zoff
+				move.w	Plr1_AngPos_w,angpos
+				move.w	Plr1_CosVal_w,cosval
+				move.w	Plr1_SinVal_w,sinval
 
 
-				move.l	PLR1_ListOfGraphRooms,ListOfGraphRooms
-				move.l	PLR1_PointsToRotatePtr,PointsToRotatePtr
-				move.b	PLR1_Echo,PLREcho
-				move.l	PLR1_Roompt,Roompt
+				move.l	Plr1_ListOfGraphRoomsPtr_l,ListOfGraphRooms
+				move.l	Plr1_PointsToRotatePtr_l,PointsToRotatePtr
+				move.b	Plr1_Echo_b,PLREcho
+				move.l	Plr1_RoomPtr_l,Roompt
 
 				move.l	#KeyMap,a5
 				moveq	#0,d5
@@ -1992,7 +1992,7 @@ IWasPlayer1:
 
 				st		DOANYWATER
 
-				move.l	PLR1_yoff,yoff
+				move.l	Plr1_YOff_l,yoff
 
 				move.w	#0,leftclip
 				move.w	RIGHTX,rightclip
@@ -2077,12 +2077,12 @@ nodrawp2:
 				bsr		DoTheMapWotNastyCharlesIsForcingMeToDo
 
 .nomap
-				move.b	PLR1_TELEPORTED,d5
-				clr.b	PLR1_TELEPORTED
+				move.b	Plr1_Teleported_b,d5
+				clr.b	Plr1_Teleported_b
 				cmp.b	#'s',mors
 				bne.s	.notplr2
-				move.b	PLR2_TELEPORTED,d5
-				clr.b	PLR2_TELEPORTED
+				move.b	Plr2_Teleported_b,d5
+				clr.b	Plr2_Teleported_b
 .notplr2
 				jsr		CHUNKYTOPLANAR
 
@@ -2189,7 +2189,7 @@ notdoubwidth2:
 
 plr1only:
 
-				move.l	PLR1_Roompt,a0
+				move.l	Plr1_RoomPtr_l,a0
 				lea		ZoneT_ListOfGraph_w(a0),a0
 .doallrooms2:
 				move.w	(a0),d0
@@ -2270,7 +2270,7 @@ noend:
 
 				cmp.b	#'n',mors
 				bne.s	noexit
-				move.l	PLR1_Roompt,a0
+				move.l	Plr1_RoomPtr_l,a0
 				move.w	(a0),d0
 
 				cmp.w	ENDZONE,d0
@@ -3225,9 +3225,9 @@ USEPLR1:
 				move.l	ObjectPoints,a1
 				move.l	#ObjRotated,a2
 				move.w	(a0),d0
-				move.l	PLR1_xoff,(a1,d0.w*8)
-				move.l	PLR1_zoff,4(a1,d0.w*8)
-				move.l	PLR1_Roompt,a1
+				move.l	Plr1_XOff_l,(a1,d0.w*8)
+				move.l	Plr1_ZOff_l,4(a1,d0.w*8)
+				move.l	Plr1_RoomPtr_l,a1
 
 				moveq	#0,d2
 				move.b	EntT_DamageTaken_b(a0),d2
@@ -3238,16 +3238,16 @@ USEPLR1:
 				beq.s	.notwist
 				move.w	d2,d4
 .notwist:
-				add.w	d3,PLR1s_xspdval
+				add.w	d3,Plr1_AltXSpdVal_l
 				move.w	EntT_ImpactZ_w(a0),d3
 				beq.s	.notwist2
 				move.w	d2,d4
 .notwist2:
-				add.w	d3,PLR1s_zspdval
+				add.w	d3,Plr1_AltZSpdVal_l
 				move.w	EntT_ImpactY_w(a0),d3
 				ext.l	d3
 				asl.l	#8,d3
-				add.l	d3,PLR1s_yvel
+				add.l	d3,Plr1_AltYVel_l
 
 				move.w	#0,EntT_ImpactX_w(a0)
 				move.w	#0,EntT_ImpactY_w(a0)
@@ -3257,7 +3257,7 @@ USEPLR1:
 				muls	d4,d0
 				asr.l	#8,d0
 				asr.l	#4,d0
-				add.w	d0,PLR1s_angspd
+				add.w	d0,Plr1_AltAngSpd_w
 
 				move.l	#7*2116,hitcol
 				sub.w	d2,PLAYERONEHEALTH
@@ -3277,13 +3277,13 @@ USEPLR1:
 				move.b	#10,EntT_NumLives_b(a0)
 
 				move.w	p1_angpos,EntT_CurrentAngle_w(a0)
-				move.b	PLR1_StoodInTop,ShotT_InUpperZone_b(a0)
+				move.b	Plr1_StoodInTop_b,ShotT_InUpperZone_b(a0)
 
 				move.w	(a1),12(a0)
 				move.w	(a1),d2
 				move.l	#ZoneBrightTable,a1
 				move.l	(a1,d2.w*4),d2
-				tst.b	PLR1_StoodInTop
+				tst.b	Plr1_StoodInTop_b
 				bne.s	.okinbott
 				swap	d2
 .okinbott:
@@ -3476,7 +3476,7 @@ USEPLR1:
 				rts
 
 .notdead:
-				move.l	PLR1_Roompt,a1
+				move.l	Plr1_RoomPtr_l,a1
 
 				move.w	EntT_CurrentAngle_w(a0),d0
 				add.w	#4096,d0
@@ -3610,7 +3610,7 @@ USEPLR2:
 				move.l	PLR1_Obj,a0
 				move.b	#4,16(a0)
 
-				move.w	PLR1_angpos,d0
+				move.w	Plr1_AngPos_w,d0
 				and.w	#8190,d0
 				move.w	d0,EntT_CurrentAngle_w(a0)
 ;
@@ -3629,18 +3629,18 @@ USEPLR2:
 				move.l	ObjectPoints,a1
 				move.l	#ObjRotated,a2
 				move.w	(a0),d0
-				move.l	PLR1_xoff,(a1,d0.w*8)
-				move.l	PLR1_zoff,4(a1,d0.w*8)
-				move.l	PLR1_Roompt,a1
+				move.l	Plr1_XOff_l,(a1,d0.w*8)
+				move.l	Plr1_ZOff_l,4(a1,d0.w*8)
+				move.l	Plr1_RoomPtr_l,a1
 
 				moveq	#0,d2
 				move.b	EntT_DamageTaken_b(a0),d2
 				beq		.notbeenshot2
 
 				move.w	EntT_ImpactX_w(a0),d3
-				add.w	d3,PLR1s_xspdval
+				add.w	d3,Plr1_AltXSpdVal_l
 				move.w	EntT_ImpactZ_w(a0),d3
-				add.w	d3,PLR1s_zspdval
+				add.w	d3,Plr1_AltZSpdVal_l
 
 				sub.w	d2,PLAYERONEHEALTH
 
@@ -3649,13 +3649,13 @@ USEPLR2:
 				move.b	#0,EntT_DamageTaken_b(a0)
 				move.b	#10,EntT_NumLives_b(a0)
 
-				move.b	PLR1_StoodInTop,ShotT_InUpperZone_b(a0)
+				move.b	Plr1_StoodInTop_b,ShotT_InUpperZone_b(a0)
 
 				move.w	(a1),12(a0)
 				move.w	(a1),d2
 				move.l	#ZoneBrightTable,a1
 				move.l	(a1,d2.w*4),d2
-				tst.b	PLR1_StoodInTop
+				tst.b	Plr1_StoodInTop_b
 				bne.s	.okinbott2
 				swap	d2
 .okinbott2:
@@ -3824,55 +3824,54 @@ endpath:
 pathpt:			dc.l	Path
 
 
-PLR1KEYS:		dc.b	0
-PLR1PATH:		dc.b	0
-PLR1MOUSE:		dc.b	-1
-PLR1JOY:		dc.b	0
-PLR2KEYS:		dc.b	0
-PLR2PATH:		dc.b	0
-PLR2MOUSE:		dc.b	-1
-PLR2JOY:		dc.b	0
+Plr1_Keys_b:		dc.b	0
+Plr1_Path_b:		dc.b	0
+Plr1_Mouse_b:		dc.b	-1
+Plr1_Joystick_b:	dc.b	0
+Plr2_Keys_b:		dc.b	0
+Plr2_Path_b:		dc.b	0
+Plr2_Mouse_b:		dc.b	-1
+Plr2_Joystick_b:	dc.b	0
 
 				even
 
-PLR1_bobble:	dc.w	0
-PLR2_bobble:	dc.w	0
+Plr1_Bobble_w:	dc.w	0
+Plr2_Bobble_w:	dc.w	0
 xwobble:		dc.l	0
 xwobxoff:		dc.w	0
-
 xwobzoff:		dc.w	0
 
 PLR1_Control:
 
 ; Take a snapshot of everything.
 
-				move.l	PLR1_xoff,d2
-				move.l	d2,PLR1_oldxoff
+				move.l	Plr1_XOff_l,d2
+				move.l	d2,Plr1_OldXOff_l
 				move.l	d2,oldx
-				move.l	PLR1_zoff,d3
-				move.l	d3,PLR1_oldzoff
+				move.l	Plr1_ZOff_l,d3
+				move.l	d3,Plr1_OldYOff_l
 				move.l	d3,oldz
 				move.l	p1_xoff,d0
-				move.l	d0,PLR1_xoff
+				move.l	d0,Plr1_XOff_l
 				move.l	d0,newx
 				move.l	p1_zoff,d1
 				move.l	d1,newz
-				move.l	d1,PLR1_zoff
+				move.l	d1,Plr1_ZOff_l
 
-				move.l	p1_height,PLR1_height
+				move.l	p1_height,Plr1_Height_l
 
 				sub.l	d2,d0
 				sub.l	d3,d1
 				move.l	d0,xdiff
 				move.l	d1,zdiff
 				move.w	p1_angpos,d0
-				move.w	d0,PLR1_angpos
+				move.w	d0,Plr1_AngPos_w
 
 				move.l	#SineTable,a1
-				move.w	(a1,d0.w),PLR1_sinval
+				move.w	(a1,d0.w),Plr1_SinVal_w
 				add.w	#2048,d0
 				and.w	#8190,d0
-				move.w	(a1,d0.w),PLR1_cosval
+				move.w	(a1,d0.w),Plr1_CosVal_w
 
 				move.l	p1_yoff,d0
 				move.w	p1_bobble,d1
@@ -3894,7 +3893,7 @@ PLR1_Control:
 
 				move.l	d1,PLR1_BOBBLEY
 
-				move.l	PLR1_height,d4
+				move.l	Plr1_Height_l,d4
 				sub.l	d1,d4
 				add.l	d1,d0
 
@@ -3903,9 +3902,9 @@ PLR1_Control:
 				asr.w	#6,d3
 				ext.l	d3
 				move.l	d3,xwobble
-				move.w	PLR1_sinval,d1
+				move.w	Plr1_SinVal_w,d1
 				muls	d3,d1
-				move.w	PLR1_cosval,d2
+				move.w	Plr1_CosVal_w,d2
 				muls	d3,d2
 				swap	d1
 				swap	d2
@@ -3916,7 +3915,7 @@ PLR1_Control:
 				move.w	d2,xwobzoff
 .otherwob
 
-				move.l	d0,PLR1_yoff
+				move.l	d0,Plr1_YOff_l
 				move.l	d0,newy
 				move.l	d0,oldy
 
@@ -3932,7 +3931,7 @@ PLR1_Control:
 
 				move.l	#$1000000,StepDownVal
 
-				move.l	PLR1_Roompt,a0
+				move.l	Plr1_RoomPtr_l,a0
 				move.w	ZoneT_TelZone_w(a0),d0
 				blt		.noteleport
 
@@ -3947,30 +3946,30 @@ PLR1_Control:
 				tst.b	hitwall
 				beq.s	.teleport
 
-				move.w	PLR1_xoff,newx
-				move.w	PLR1_zoff,newz
+				move.w	Plr1_XOff_l,newx
+				move.w	Plr1_ZOff_l,newz
 				bra		.noteleport
 
 .teleport:
 
-				st		PLR1_TELEPORTED
+				st		Plr1_Teleported_b
 
-				move.l	PLR1_Roompt,a0
+				move.l	Plr1_RoomPtr_l,a0
 				move.w	ZoneT_TelZone_w(a0),d0
-				move.w	ZoneT_TelX_w(a0),PLR1_xoff
-				move.w	ZoneT_TelZ_w(a0),PLR1_zoff
-				move.l	PLR1_yoff,d1
+				move.w	ZoneT_TelX_w(a0),Plr1_XOff_l
+				move.w	ZoneT_TelZ_w(a0),Plr1_ZOff_l
+				move.l	Plr1_YOff_l,d1
 				sub.l	ZoneT_Floor_l(a0),d1
 				move.l	ZoneAdds,a0
 				move.l	(a0,d0.w*4),a0
 				add.l	LEVELDATA,a0
-				move.l	a0,PLR1_Roompt
+				move.l	a0,Plr1_RoomPtr_l
 				add.l	ZoneT_Floor_l(a0),d1
-				move.l	d1,PLR1s_yoff
-				move.l	d1,PLR1_yoff
-				move.l	d1,PLR1s_tyoff
-				move.l	PLR1_xoff,PLR1s_xoff
-				move.l	PLR1_zoff,PLR1s_zoff
+				move.l	d1,Plr1_AltYOff_l
+				move.l	d1,Plr1_YOff_l
+				move.l	d1,Plr1_AltTYOff_l
+				move.l	Plr1_XOff_l,Plr1_AltXOff_l
+				move.l	Plr1_ZOff_l,Plr1_AltZOff_l
 
 				SAVEREGS
 				move.w	#0,Noisex
@@ -3985,9 +3984,9 @@ PLR1_Control:
 
 .noteleport:
 
-				move.l	PLR1_Roompt,objroom
+				move.l	Plr1_RoomPtr_l,objroom
 				move.w	#%100000000,wallflags
-				move.b	PLR1_StoodInTop,StoodInTop
+				move.b	Plr1_StoodInTop_b,StoodInTop
 
 				move.l	#%1011111110111000011,CollideFlags
 				move.l	PLR1_Obj,a0
@@ -3996,10 +3995,10 @@ PLR1_Control:
 				jsr		Collision
 				tst.b	hitwall
 				beq.s	.nothitanything
-				move.w	oldx,PLR1_xoff
-				move.w	oldz,PLR1_zoff
-				move.l	PLR1_xoff,PLR1s_xoff
-				move.l	PLR1_zoff,PLR1s_zoff
+				move.w	oldx,Plr1_XOff_l
+				move.w	oldz,Plr1_ZOff_l
+				move.l	Plr1_XOff_l,Plr1_AltXOff_l
+				move.l	Plr1_ZOff_l,Plr1_AltZOff_l
 				bra		.cantmove
 .nothitanything:
 
@@ -4009,34 +4008,34 @@ PLR1_Control:
 				clr.b	exitfirst
 				clr.b	wallbounce
 				bsr		MoveObject
-				move.b	StoodInTop,PLR1_StoodInTop
-				move.l	objroom,PLR1_Roompt
-				move.w	newx,PLR1_xoff
-				move.w	newz,PLR1_zoff
-				move.l	PLR1_xoff,PLR1s_xoff
-				move.l	PLR1_zoff,PLR1s_zoff
+				move.b	StoodInTop,Plr1_StoodInTop_b
+				move.l	objroom,Plr1_RoomPtr_l
+				move.w	newx,Plr1_XOff_l
+				move.w	newz,Plr1_ZOff_l
+				move.l	Plr1_XOff_l,Plr1_AltXOff_l
+				move.l	Plr1_ZOff_l,Plr1_AltZOff_l
 
 .cantmove:
 
-				move.l	PLR1_Roompt,a0
+				move.l	Plr1_RoomPtr_l,a0
 
 				move.l	ZoneT_Floor_l(a0),d0
-				tst.b	PLR1_StoodInTop
+				tst.b	Plr1_StoodInTop_b
 				beq.s	notintop
 				move.l	ZoneT_UpperFloor_l(a0),d0
 notintop:
 
 				adda.w	#ZoneT_Points_w,a0
-				sub.l	PLR1_height,d0
-				move.l	d0,PLR1s_tyoff
+				sub.l	Plr1_Height_l,d0
+				move.l	d0,Plr1_AltTYOff_l
 				move.w	p1_angpos,tmpangpos
 
 ; move.l (a0),a0		; jump to viewpoint list
 * A0 is pointing at a pointer to list of points to rotate
 				move.w	(a0)+,d1
 				ext.l	d1
-				add.l	PLR1_Roompt,d1
-				move.l	d1,PLR1_PointsToRotatePtr
+				add.l	Plr1_RoomPtr_l,d1
+				move.l	d1,Plr1_PointsToRotatePtr_l
 				tst.b	(a0)+
 				sne		DRAWNGRAPHTOP
 				beq.s	nobackgraphics
@@ -4047,10 +4046,10 @@ notintop:
 				move.l	(a7)+,a0
 nobackgraphics:
 
-				move.b	(a0)+,PLR1_Echo
+				move.b	(a0)+,Plr1_Echo_b
 
 				adda.w	#10,a0
-				move.l	a0,PLR1_ListOfGraphRooms
+				move.l	a0,Plr1_ListOfGraphRoomsPtr_l
 
 *************************************************
 				rts
@@ -4169,7 +4168,7 @@ PLR2_Control:
 
 .teleport:
 
-				st		PLR2_TELEPORTED
+				st		Plr2_Teleported_b
 
 				move.l	PLR2_Roompt,a0
 				move.w	ZoneT_TelZone_w(a0),d0
@@ -4553,7 +4552,7 @@ jumpoutofrooms:
 				beq.s	drawslavegun
 
 				moveq	#0,d0
-				move.b	PLR1_GunSelected,d0
+				move.b	Plr1_GunSelected_w,d0
 				moveq	#0,d1
 				move.b	PLR1_GunFrame,d1
 ; bsr DRAWINGUN
@@ -5311,8 +5310,8 @@ PLR2_ObjDists
 
 CalcPLR1InLine:
 
-				move.w	PLR1_sinval,d5
-				move.w	PLR1_cosval,d6
+				move.w	Plr1_SinVal_w,d5
+				move.w	Plr1_CosVal_w,d6
 				move.l	ObjectData,a4
 				move.l	ObjectPoints,a0
 				move.w	NumObjectPoints,d7
@@ -5325,7 +5324,7 @@ CalcPLR1InLine:
 				beq.s	.itaux
 
 				move.w	(a0),d0
-				sub.w	PLR1_xoff,d0
+				sub.w	Plr1_XOff_l,d0
 				move.w	4(a0),d1
 				addq	#8,a0
 
@@ -5337,7 +5336,7 @@ CalcPLR1InLine:
 ;move.l #ColBoxTable,a6
 ;lea (a6,d2.w*8),a6
 
-				sub.w	PLR1_zoff,d1
+				sub.w	Plr1_ZOff_l,d1
 				move.w	d0,d2
 				muls	d6,d2
 				move.w	d1,d3
@@ -9887,21 +9886,21 @@ dosomething:
 
 				move.w	#100,timetodamage
 
-				move.l	PLR1_Roompt,a0
+				move.l	Plr1_RoomPtr_l,a0
 				move.l	ZoneT_Water_l(a0),d2      ; Water depth in d2
 				move.w	ZoneT_FloorNoise_w(a0),d0
-				tst.b	PLR1_StoodInTop
+				tst.b	Plr1_StoodInTop_b
 				beq.s	.okinbot
 				move.w	ZoneT_UpperFloorNoise_w(a0),d0
 
 .okinbot:
 				; Issue #1 - Check we are on the floor or swimming before applying any floor damage.
-				cmp.l	PLR1s_yoff,d2
+				cmp.l	Plr1_AltYOff_l,d2
 				blt.b   .in_toxic_liquid1
 
 				; Player not in liquid, check if on floor.
-				move.l	PLR1s_tyoff,d1
-				cmp.l	PLR1s_yoff,d1
+				move.l	Plr1_AltTYOff_l,d1
+				cmp.l	Plr1_AltYOff_l,d1
 				bgt.b	.not_on_floor1
 
 .in_toxic_liquid1:
@@ -10382,7 +10381,7 @@ nostartalan:
 				clr.b	PLR1_fire
 				clr.b	PLR1_clicked
 				move.w	#0,ADDTOBOBBLE
-				move.l	#playercrouched,PLR1s_height
+				move.l	#playercrouched,Plr1_AltHeight_l
 				move.w	#-80,d0					; Is this related to render buffer height
 				move.w	d0,STOPOFFSET
 				neg.w	d0
@@ -10392,8 +10391,8 @@ nostartalan:
 				move.l	d0,SBIGMIDDLEY
 				jsr		PLR1_fall
 
-				move.l	PLR1s_xspdval,d6
-				move.l	PLR1s_zspdval,d7
+				move.l	Plr1_AltXSpdVal_l,d6
+				move.l	Plr1_AltZSpdVal_l,d7
 
 				tst.b	SLOWDOWN
 				beq.s	.nofriction
@@ -10416,16 +10415,16 @@ nostartalan:
 				asr.l	#3,d7
 .bug2:
 
-				add.l	d6,PLR1s_xspdval
-				add.l	d7,PLR1s_zspdval
+				add.l	d6,Plr1_AltXSpdVal_l
+				add.l	d7,Plr1_AltZSpdVal_l
 
 .nofriction:
-				move.l	PLR1s_xspdval,d6
-				move.l	PLR1s_zspdval,d7
-				add.l	d6,PLR1s_xoff
-				add.l	d7,PLR1s_zoff
+				move.l	Plr1_AltXSpdVal_l,d6
+				move.l	Plr1_AltZSpdVal_l,d7
+				add.l	d6,Plr1_AltXOff_l
+				add.l	d7,Plr1_AltZOff_l
 
-				move.w	PLR1s_angspd,d3
+				move.w	Plr1_AltAngSpd_w,d3
 				tst.b	SLOWDOWN
 				beq.s	.nofric
 				asr.w	#2,d3
@@ -10434,35 +10433,34 @@ nostartalan:
 .nneg:
 .nofric:
 
-				move.w	d3,PLR1s_angspd
-				add.w	d3,PLR1s_angpos
-				add.w	d3,PLR1s_angpos
-				and.w	#8190,PLR1s_angpos
+				move.w	d3,Plr1_AltAngSpd_w
+				add.w	d3,Plr1_AltAngPos_w
+				add.w	d3,Plr1_AltAngPos_w
+				and.w	#8190,Plr1_AltAngPos_w
 
 				bra		nocontrols
 
 .propercontrol:
 
-				tst.b	PLR1MOUSE
-				beq.s	PLR1_nomouse
+				tst.b	Plr1_Mouse_b
+				beq.s	.plr1_no_mouse
 				bsr		PLR1_mouse_control
-PLR1_nomouse:
-				tst.b	PLR1KEYS
-				beq.s	PLR1_nokeys
+.plr1_no_mouse:
+				tst.b	Plr1_Keys_b
+				beq.s	.plr1_no_keyboard
 				bsr		PLR1_keyboard_control
-PLR1_nokeys:
-; tst.b PLR1PATH
+.plr1_no_keyboard:
+; tst.b Plr1_Path_b
 ; beq.s PLR1_nopath
 ; bsr PLR1_follow_path
 ;PLR1_nopath:
-				tst.b	PLR1JOY
-				beq.s	PLR1_nojoy
+				tst.b	Plr1_Joystick_b
+				beq.s	.plr1_no_joystick
 				bsr		PLR1_JoyStick_control
-PLR1_nojoy:
+.plr1_no_joystick:
 				bra		nocontrols
 
 control2:
-
 				tst.w	PLAYERTWOHEALTH
 				bgt		.propercontrol
 
@@ -10521,37 +10519,34 @@ control2:
 				asr.w	#2,d3
 				bge.s	.nneg
 				addq	#1,d3
+
 .nneg:
 .nofric:
-
 				move.w	d3,PLR2s_angspd
 				add.w	d3,PLR2s_angpos
 				add.w	d3,PLR2s_angpos
 				and.w	#8190,PLR2s_angpos
-
 				bra.s	nocontrols
 
 .propercontrol:
-				tst.b	PLR2MOUSE
-				beq.s	PLR2_nomouse
+				tst.b	Plr2_Mouse_b
+				beq.s	.plr2_no_mouse
 				bsr		PLR2_mouse_control
-PLR2_nomouse:
-				tst.b	PLR2KEYS
-				beq.s	PLR2_nokeys
+.plr2_no_mouse:
+				tst.b	Plr2_Keys_b
+				beq.s	.plr2_no_keyboard
 				bsr		PLR2_keyboard_control
-PLR2_nokeys:
-; tst.b PLR2PATH
-; beq.s PLR2_nopath
+.plr2_no_keyboard:
+; tst.b Plr2_Path_b
+; beq.s .plr2_no_path
 ; bsr PLR1_follow_path
-;PLR2_nopath:
-				tst.b	PLR2JOY
-				beq.s	PLR2_nojoy
+;.plr2_no_path:
+				tst.b	Plr2_Joystick_b
+				beq.s	.plr2_no_joystick
 				bsr		PLR2_JoyStick_control
-PLR2_nojoy:
-
+.plr2_no_joystick:
 
 nocontrols:
-
 				move.l	#$dff000,a6
 
 				tst.b	dosounds
@@ -12006,39 +12001,40 @@ xspdval:		dc.l	0
 zspdval:		dc.l	0
 Zone:			dc.w	0
 
+; Player data definiton - TODO remove unused, tighten definitions, fix alignments
 PLR1:			dc.b	$ff
 				even
-PLR1_energy:	dc.w	191
-PLR1_GunSelected: dc.w	0
-PLR1_cosval:	dc.w	0
-PLR1_sinval:	dc.w	0
-PLR1_angpos:	dc.w	0
-PLR1_angspd:	dc.w	0
-PLR1_xoff:		dc.l	0
-PLR1_yoff:		dc.l	0
-PLR1_yvel:		dc.l	0
-PLR1_zoff:		dc.l	0
-PLR1_tyoff:		dc.l	0
-PLR1_xspdval:	dc.l	0
-PLR1_zspdval:	dc.l	0
-PLR1_Zone:		dc.w	0
-PLR1_Roompt:	dc.l	0
-PLR1_FloorSpd:	dc.l	0
-PLR2_FloorSpd:	dc.l	0
-PLR1_OldRoompt:	dc.l	0
-PLR1_PointsToRotatePtr: dc.l 0
-PLR1_ListOfGraphRooms: dc.l 0
-PLR1_oldxoff:	dc.l	0
-PLR1_oldzoff:	dc.l	0
-PLR1_StoodInTop: dc.b	0
+Plr1_Energy_w:	dc.w	191
+Plr1_GunSelected_w: dc.w	0
+Plr1_CosVal_w:	dc.w	0
+Plr1_SinVal_w:	dc.w	0
+Plr1_AngPos_w:	dc.w	0
+Plr1_AngSpd_w:	dc.w	0 ; unused
+Plr1_XOff_l:		dc.l	0 ; sometimes accessed as w - todo understand real size
+Plr1_YOff_l:		dc.l	0
+Plr1_YVel_l:		dc.l	0 ; write once, never read
+Plr1_ZOff_l:		dc.l	0
+Plr1_TYOff_l:		dc.l	0 ; unused
+Plr1_XSpdVal_l:	dc.l	0 ; write once, never read
+Plr1_ZSpdVal_l:	dc.l	0 ; write once, never read
+Plr1_Zone_w:		dc.w	0
+Plr1_RoomPtr_l:	dc.l	0
+Plr1_FloorSpd_l:	dc.l	0
+Plr2_FloorSpd_l:	dc.l	0
+Plr1_OldRoomPtr_l:	dc.l	0
+Plr1_PointsToRotatePtr_l: dc.l 0
+Plr1_ListOfGraphRoomsPtr_l: dc.l 0
+Plr1_OldXOff_l:	dc.l	0 ; write once, never read
+Plr1_OldYOff_l:	dc.l	0 ; write once, never read
+Plr1_StoodInTop_b: dc.b	0
 				even
-PLR1_height:	dc.l	0
-PLR1_RoomBright: dc.w	0
+Plr1_Height_l:	dc.l	0
+Plr1_RoomBright_w: dc.w	0
 
 DOUBLEWIDTH:	dc.b	$0,0
 DOUBLEHEIGHT:	dc.b	0,0
-PLR1_TELEPORTED: dc.w	0
-PLR2_TELEPORTED: dc.w	0
+Plr1_Teleported_b: dc.w	0 ; delcared as word, accessed as byte
+Plr2_Teleported_b: dc.w	0 ; delcared as word, accessed as byte
 
 				ds.w	4
 
@@ -12052,28 +12048,28 @@ ZDIFF1:			dc.l	0
 XDIFF2:			dc.l	0
 ZDIFF2:			dc.l	0
 
-PLR1s_cosval:	dc.w	0
-PLR1s_sinval:	dc.w	0
-PLR1s_angpos:	dc.w	0
-PLR1s_angspd:	dc.w	0
-PLR1s_xoff:		dc.l	0
-PLR1s_yoff:		dc.l	0
-PLR1s_yvel:		dc.l	0
-PLR1s_zoff:		dc.l	0
-PLR1s_tyoff:	dc.l	0
-PLR1s_xspdval:	dc.l	0
-PLR1s_zspdval:	dc.l	0
-PLR1s_Zone:		dc.w	0
-PLR1s_Roompt:	dc.l	0
-PLR1s_OldRoompt: dc.l	0
-PLR1s_PointsToRotatePtr: dc.l 0
-PLR1s_ListOfGraphRooms: dc.l 0
-PLR1s_oldxoff:	dc.l	0
-PLR1s_oldzoff:	dc.l	0
-PLR1s_height:	dc.l	0
-PLR1s_targheight: dc.l	0
+Plr1_AltCosVal_w:	dc.w	0
+Plr1_AltSinVal_w:	dc.w	0
+Plr1_AltAngPos_w:	dc.w	0
+Plr1_AltAngSpd_w:	dc.w	0
+Plr1_AltXOff_l:		dc.l	0
+Plr1_AltYOff_l:		dc.l	0
+Plr1_AltYVel_l:		dc.l	0
+Plr1_AltZOff_l:		dc.l	0
+Plr1_AltTYOff_l:	dc.l	0
+Plr1_AltXSpdVal_l:	dc.l	0
+Plr1_AltZSpdVal_l:	dc.l	0
+Plr1_AltZone_w:		dc.w	0 ; unused
+Plr1_AltRoomPtr_l:	dc.l	0 ; unused
+Plr1_AltOldRoomPtr_l: dc.l	0 ; unused
+Plr1_AltPointsToRotatePtr_l: dc.l 0 ; unused
+Plr1_AltListOfGraphRooms_l: dc.l 0 ; unused
+Plr1_AltOldXOff_l:	dc.l	0 ; unused
+Plr1_AltOldZOff_l:	dc.l	0 ; unused
+Plr1_AltHeight_l:	dc.l	0
+Plr1_AltTargHeight_l: dc.l	0
 
-PLR1_Echo:		dc.w	0
+Plr1_Echo_b:		dc.w	0 ; declared as word, accessed as byte
 
 p1_xoff:		dc.l	0
 p1_zoff:		dc.l	0

--- a/ab3d2_source/hires.s
+++ b/ab3d2_source/hires.s
@@ -606,7 +606,7 @@ noclips:
 ;njc:
 
 				clr.b	Plr1_StoodInTop_b
-				move.l	#playerheight,Plr1_AltHeight_l
+				move.l	#playerheight,Plr1_SnapHeight_l
 
 				move.l	#empty,pos1LEFT
 				move.l	#empty,pos2LEFT
@@ -744,10 +744,10 @@ scaledownlop:
 
 				move.l	SampleList+6*8,pos0LEFT
 				move.l	SampleList+6*8+4,Samp0endLEFT
-				move.l	#playerheight,Plr1_AltTargHeight_l
-				move.l	#playerheight,Plr1_AltHeight_l
-				move.l	#playerheight,PLR2s_targheight
-				move.l	#playerheight,PLR2s_height
+				move.l	#playerheight,Plr1_SnapTargHeight_l
+				move.l	#playerheight,Plr1_SnapHeight_l
+				move.l	#playerheight,Plr2_SnapTargHeight_l
+				move.l	#playerheight,Plr2_SnapHeight_l
 
 ; cmp.b #'n',mors
 ; beq.s nohandshake
@@ -821,8 +821,8 @@ NOCLTXT:
 
 				clr.b	PLR1_Ducked
 				clr.b	PLR2_Ducked
-				clr.b	p1_ducked
-				clr.b	p2_ducked
+				clr.b	Plr1_TmpDucked_b
+				clr.b	Plr2_TmpDucked_b
 
 ********************************************
 
@@ -953,9 +953,9 @@ clrmessbuff:
 				jsr		SENDMESSAGE
 
 				clr.b	PLR2_fire
-				clr.b	p2_fire
+				clr.b	Plr2_TmpFire_b
 				clr.b	PLR2_SPCTAP
-				clr.b	p2_spctap
+				clr.b	Plr2_TmpSpcTap_b
 
 				clr.b	PLR1_dead
 				clr.b	PLR2_dead
@@ -969,15 +969,12 @@ clrmessbuff:
 				move.w	#0,EntT_ImpactY_w(a1)
 				move.w	#0,EntT_ImpactZ_w(a1)
 
-				move.l	#0,Plr1_AltXSpdVal_l
-				move.l	#0,Plr1_AltZSpdVal_l
-				move.l	#0,Plr1_AltYVel_l
-				move.l	#0,PLR2s_xspdval
-				move.l	#0,PLR2s_zspdval
-				move.l	#0,PLR2s_yvel
-				move.l	#0,PLR2_xspdval
-				move.l	#0,PLR2_zspdval
-				move.l	#0,PLR2_yvel
+				move.l	#0,Plr1_SnapXSpdVal_l
+				move.l	#0,Plr1_SnapZSpdVal_l
+				move.l	#0,Plr1_SnapYVel_l
+				move.l	#0,Plr2_SnapXSpdVal_l
+				move.l	#0,Plr2_SnapZSpdVal_l
+				move.l	#0,Plr2_SnapYVel_l
 
 				jsr	FPS_time1
 lop:
@@ -1017,10 +1014,10 @@ lop:
 				move.b	AlienT_SplatType_w+1(a6),d0
 				move.b	d0,TypeOfSplat
 
-				move.l	PLR2_Roompt,a1
+				move.l	Plr2_RoomPtr_l,a1
 				move.w	(a1),12(a0)
-				move.w	p2_xoff,newx
-				move.w	p2_zoff,newz
+				move.w	Plr2_TmpXOff_l,newx
+				move.w	Plr2_TmpZOff_l,newz
 				move.w	#7,d2
 				jsr		ExplodeIntoBits
 				move.w	#-1,12(a0)
@@ -1063,8 +1060,8 @@ lop:
 
 				move.l	Plr1_RoomPtr_l,a1
 				move.w	(a1),12(a0)
-				move.w	p1_xoff,newx
-				move.w	p1_zoff,newz
+				move.w	Plr1_TmpXOff_l,newx
+				move.w	Plr1_TmpZOff_l,newz
 				move.w	#7,d2
 				jsr		ExplodeIntoBits
 				move.w	#-1,12(a0)
@@ -1231,12 +1228,12 @@ nofadedownhc:
 ;				move.w	#$1,intreq(a6)
 
 ; move.l #PLR1_GunData,GunData
-				move.b	Plr1_GunSelected_w,GunSelected
+				move.b	Plr1_GunSelected_b,GunSelected
 				bra		waitmaster
 
 nowaitslave:
 ; move.l #PLR2_GunData,GunData
-				move.b	PLR2_GunSelected,GunSelected
+				move.b	Plr2_GunSelected_b,GunSelected
 waitmaster:
 
 *****************************************************************
@@ -1300,10 +1297,10 @@ okwat:
 				add.l	#1,wateroff
 				and.l	#$3fff3fff,wateroff
 
-				move.l	Plr1_XOff_l,OLDX1
-				move.l	Plr1_ZOff_l,OLDZ1
-				move.l	PLR2_xoff,OLDX2
-				move.l	PLR2_zoff,OLDZ2
+				move.l	Plr1_XOff_l,OldX1_l
+				move.l	Plr1_ZOff_l,OldZ1_l
+				move.l	Plr2_XOff_l,OldX2_l
+				move.l	Plr2_ZOff_l,OldZ2_l
 
 				move.l	#$dff000,a6
 
@@ -1366,34 +1363,34 @@ okwat:
 **********************************************
 **********************************************
 
-				move.l	Plr1_AltXOff_l,p1_xoff
-				move.l	Plr1_AltZOff_l,p1_zoff
-				move.l	Plr1_AltYOff_l,p1_yoff
-				move.l	Plr1_AltHeight_l,p1_height
-				move.w	Plr1_AltAngPos_w,p1_angpos
-				move.w	Plr1_Bobble_w,p1_bobble
-				move.b	PLR1_clicked,p1_clicked
-				move.b	PLR1_fire,p1_fire
+				move.l	Plr1_SnapXOff_l,Plr1_TmpXOff_l
+				move.l	Plr1_SnapZOff_l,Plr1_TmpZOff_l
+				move.l	Plr1_SnapYOff_l,Plr1_TmpYOff_l
+				move.l	Plr1_SnapHeight_l,Plr1_TmpHeight_l
+				move.w	Plr1_SnapAngPos_w,Plr1_TmpAngPos_w
+				move.w	Plr1_Bobble_w,Plr1_TmpBobble_w
+				move.b	PLR1_clicked,Plr1_TmpClicked_b
+				move.b	PLR1_fire,Plr1_TmpFire_b
 				clr.b	PLR1_clicked
-				move.b	PLR1_SPCTAP,p1_spctap
+				move.b	PLR1_SPCTAP,Plr1_TmpSpcTap_b
 				clr.b	PLR1_SPCTAP
-				move.b	PLR1_Ducked,p1_ducked
-				move.b	Plr1_GunSelected_w,p1_gunselected
+				move.b	PLR1_Ducked,Plr1_TmpDucked_b
+				move.b	Plr1_GunSelected_b,Plr1_TmpGunSelected_b
 
 				bsr		PLR1_Control
 
 				move.l	Plr1_RoomPtr_l,a0
 				move.l	ZoneT_Roof_l(a0),SplitHeight
-				move.w	p1_xoff,THISPLRxoff
-				move.w	p1_zoff,THISPLRzoff
+				move.w	Plr1_TmpXOff_l,THISPLRxoff
+				move.w	Plr1_TmpZOff_l,THISPLRzoff
 
 
-				move.l	#$60000,p2_yoff
+				move.l	#$60000,Plr2_TmpYOff_l
 				move.l	PLR2_Obj,a0
 				move.w	#-1,EntT_GraphicRoom_w(a0)
 				move.w	#-1,12(a0)
 				move.b	#0,17(a0)
-				move.l	#BollocksRoom,PLR2_Roompt
+				move.l	#BollocksRoom,Plr2_RoomPtr_l
 
 				bra		donetalking
 
@@ -1428,71 +1425,71 @@ NotOnePlayer:
 .okframe:
 				move.w	#0,FramesToDraw
 
-				move.l	Plr1_AltXOff_l,p1_xoff
-				move.l	Plr1_AltZOff_l,p1_zoff
-				move.l	Plr1_AltYOff_l,p1_yoff
-				move.l	Plr1_AltHeight_l,p1_height
-				move.w	Plr1_AltAngPos_w,p1_angpos
-				move.w	Plr1_Bobble_w,p1_bobble
-				move.b	PLR1_clicked,p1_clicked
+				move.l	Plr1_SnapXOff_l,Plr1_TmpXOff_l
+				move.l	Plr1_SnapZOff_l,Plr1_TmpZOff_l
+				move.l	Plr1_SnapYOff_l,Plr1_TmpYOff_l
+				move.l	Plr1_SnapHeight_l,Plr1_TmpHeight_l
+				move.w	Plr1_SnapAngPos_w,Plr1_TmpAngPos_w
+				move.w	Plr1_Bobble_w,Plr1_TmpBobble_w
+				move.b	PLR1_clicked,Plr1_TmpClicked_b
 				clr.b	PLR1_clicked
-				move.b	PLR1_fire,p1_fire
-				move.b	PLR1_SPCTAP,p1_spctap
+				move.b	PLR1_fire,Plr1_TmpFire_b
+				move.b	PLR1_SPCTAP,Plr1_TmpSpcTap_b
 				clr.b	PLR1_SPCTAP
-				move.b	PLR1_Ducked,p1_ducked
-				move.b	Plr1_GunSelected_w,p1_gunselected
+				move.b	PLR1_Ducked,Plr1_TmpDucked_b
+				move.b	Plr1_GunSelected_b,Plr1_TmpGunSelected_b
 
 				move.l	PLR1_AIMSPD,d0
 				jsr		SENDFIRST
 				move.l	d0,PLR2_AIMSPD
 
-				move.l	p1_xoff,d0
+				move.l	Plr1_TmpXOff_l,d0
 				jsr		SENDFIRST
-				move.l	d0,p2_xoff
+				move.l	d0,Plr2_TmpXOff_l
 
-				move.l	p1_zoff,d0
+				move.l	Plr1_TmpZOff_l,d0
 				jsr		SENDFIRST
-				move.l	d0,p2_zoff
+				move.l	d0,Plr2_TmpZOff_l
 
-				move.l	p1_yoff,d0
+				move.l	Plr1_TmpYOff_l,d0
 				jsr		SENDFIRST
-				move.l	d0,p2_yoff
+				move.l	d0,Plr2_TmpYOff_l
 
-				move.l	p1_height,d0
+				move.l	Plr1_TmpHeight_l,d0
 				jsr		SENDFIRST
-				move.l	d0,p2_height
+				move.l	d0,Plr2_TmpHeight_l
 
-				move.w	p1_angpos,d0
+				move.w	Plr1_TmpAngPos_w,d0
 				swap	d0
-				move.w	p1_bobble,d0
+				move.w	Plr1_TmpBobble_w,d0
 				jsr		SENDFIRST
-				move.w	d0,p2_bobble
+				move.w	d0,Plr2_TmpBobble_w
 				swap	d0
-				move.w	d0,p2_angpos
+				move.w	d0,Plr2_TmpAngPos_w
 
 
 				move.w	TempFrames,d0
 				swap	d0
-				move.b	p1_spctap,d0
+				move.b	Plr1_TmpSpcTap_b,d0
 				lsl.w	#8,d0
-				move.b	p1_clicked,d0
+				move.b	Plr1_TmpClicked_b,d0
 				jsr		SENDFIRST
-				move.b	d0,p2_clicked
+				move.b	d0,Plr2_TmpClicked_b
 				lsr.w	#8,d0
-				move.b	d0,p2_spctap
+				move.b	d0,Plr2_TmpSpcTap_b
 
 				move.w	Rand1,d0
 				swap	d0
-				move.b	p1_ducked,d0
+				move.b	Plr1_TmpDucked_b,d0
 				or.b	PLR1_Squished,d0
 				lsl.w	#8,d0
-				move.b	p1_gunselected,d0
+				move.b	Plr1_TmpGunSelected_b,d0
 				jsr		SENDFIRST
-				move.b	d0,p2_gunselected
+				move.b	d0,Plr2_TmpGunSelected_b
 				lsr.w	#8,d0
-				move.b	d0,p2_ducked
+				move.b	d0,Plr2_TmpDucked_b
 
-				move.b	p1_fire,d0
+				move.b	Plr1_TmpFire_b,d0
 				lsl.w	#8,d0
 				move.b	MASTERQUITTING,d0
 				or.b	d0,SLAVEQUITTING
@@ -1506,7 +1503,7 @@ NotOnePlayer:
 				or.b	d0,SLAVEQUITTING
 				or.b	d0,MASTERQUITTING
 				lsr.w	#8,d0
-				move.b	d0,p2_fire
+				move.b	d0,Plr2_TmpFire_b
 
 				move.w	PLAYERONEHEALTH,d0
 				jsr		SENDFIRST
@@ -1516,8 +1513,8 @@ NotOnePlayer:
 				bsr		PLR2_Control
 				move.l	Plr1_RoomPtr_l,a0
 				move.l	ZoneT_Roof_l(a0),SplitHeight
-				move.w	p1_xoff,THISPLRxoff
-				move.w	p1_zoff,THISPLRzoff
+				move.w	Plr1_TmpXOff_l,THISPLRxoff
+				move.w	Plr1_TmpZOff_l,THISPLRzoff
 
 				bra		donetalking
 
@@ -1551,71 +1548,71 @@ ASlaveShouldWaitOnHisMaster:
 
 
 
-				move.l	PLR2s_xoff,p2_xoff
-				move.l	PLR2s_zoff,p2_zoff
-				move.l	PLR2s_yoff,p2_yoff
-				move.l	PLR2s_height,p2_height
-				move.w	PLR2s_angpos,p2_angpos
-				move.w	Plr2_Bobble_w,p2_bobble
-				move.b	PLR2_clicked,p2_clicked
+				move.l	Plr2_SnapXOff_l,Plr2_TmpXOff_l
+				move.l	Plr2_SnapZOff_l,Plr2_TmpZOff_l
+				move.l	Plr2_SnapYOff_l,Plr2_TmpYOff_l
+				move.l	Plr2_SnapHeight_l,Plr2_TmpHeight_l
+				move.w	Plr2_SnapAngPos_w,Plr2_TmpAngPos_w
+				move.w	Plr2_Bobble_w,Plr2_TmpBobble_w
+				move.b	PLR2_clicked,Plr2_TmpClicked_b
 				clr.b	PLR2_clicked
-				move.b	PLR2_fire,p2_fire
-				move.b	PLR2_SPCTAP,p2_spctap
+				move.b	PLR2_fire,Plr2_TmpFire_b
+				move.b	PLR2_SPCTAP,Plr2_TmpSpcTap_b
 				clr.b	PLR2_SPCTAP
-				move.b	PLR2_Ducked,p2_ducked
-				move.b	PLR2_GunSelected,p2_gunselected
+				move.b	PLR2_Ducked,Plr2_TmpDucked_b
+				move.b	Plr2_GunSelected_b,Plr2_TmpGunSelected_b
 
 				move.l	PLR2_AIMSPD,d0
 				jsr		RECFIRST
 				move.l	d0,PLR1_AIMSPD
 
-				move.l	p2_xoff,d0
+				move.l	Plr2_TmpXOff_l,d0
 				jsr		RECFIRST
-				move.l	d0,p1_xoff
+				move.l	d0,Plr1_TmpXOff_l
 
-				move.l	p2_zoff,d0
+				move.l	Plr2_TmpZOff_l,d0
 				jsr		RECFIRST
-				move.l	d0,p1_zoff
+				move.l	d0,Plr1_TmpZOff_l
 
-				move.l	p2_yoff,d0
+				move.l	Plr2_TmpYOff_l,d0
 				jsr		RECFIRST
-				move.l	d0,p1_yoff
+				move.l	d0,Plr1_TmpYOff_l
 
-				move.l	p2_height,d0
+				move.l	Plr2_TmpHeight_l,d0
 				jsr		RECFIRST
-				move.l	d0,p1_height
+				move.l	d0,Plr1_TmpHeight_l
 
-				move.w	p2_angpos,d0
+				move.w	Plr2_TmpAngPos_w,d0
 				swap	d0
-				move.w	p2_bobble,d0
+				move.w	Plr2_TmpBobble_w,d0
 				jsr		RECFIRST
-				move.w	d0,p1_bobble
+				move.w	d0,Plr1_TmpBobble_w
 				swap	d0
-				move.w	d0,p1_angpos
+				move.w	d0,Plr1_TmpAngPos_w
 
 
-				move.b	p2_spctap,d0
+				move.b	Plr2_TmpSpcTap_b,d0
 				lsl.w	#8,d0
-				move.b	p2_clicked,d0
+				move.b	Plr2_TmpClicked_b,d0
 				jsr		RECFIRST
-				move.b	d0,p1_clicked
+				move.b	d0,Plr1_TmpClicked_b
 				lsr.w	#8,d0
-				move.b	d0,p1_spctap
+				move.b	d0,Plr1_TmpSpcTap_b
 				swap	d0
 				move.w	d0,TempFrames
 
-				move.b	p2_ducked,d0
+				move.b	Plr2_TmpDucked_b,d0
 				or.b	PLR2_Squished,d0
 				lsl.w	#8,d0
-				move.b	p2_gunselected,d0
+				move.b	Plr2_TmpGunSelected_b,d0
 				jsr		RECFIRST
-				move.b	d0,p1_gunselected
+				move.b	d0,Plr1_TmpGunSelected_b
 				lsr.w	#8,d0
-				move.b	d0,p1_ducked
+				move.b	d0,Plr1_TmpDucked_b
 				swap	d0
 				move.w	d0,Rand1
 
-				move.b	p2_fire,d0
+				move.b	Plr2_TmpFire_b,d0
 				lsl.w	#8,d0
 				move.b	SLAVEQUITTING,d0
 				or.b	d0,MASTERQUITTING
@@ -1629,7 +1626,7 @@ ASlaveShouldWaitOnHisMaster:
 				or.b	d0,SLAVEQUITTING
 				or.b	d0,MASTERQUITTING
 				lsr.w	#8,d0
-				move.b	d0,p1_fire
+				move.b	d0,Plr1_TmpFire_b
 
 				move.w	PLAYERTWOHEALTH,d0
 				jsr		RECFIRST
@@ -1637,9 +1634,9 @@ ASlaveShouldWaitOnHisMaster:
 
 				bsr		PLR1_Control
 				bsr		PLR2_Control
-				move.w	p2_xoff,THISPLRxoff
-				move.w	p2_zoff,THISPLRzoff
-				move.l	PLR2_Roompt,a0
+				move.w	Plr2_TmpXOff_l,THISPLRxoff
+				move.w	Plr2_TmpZOff_l,THISPLRzoff
+				move.l	Plr2_RoomPtr_l,a0
 				move.l	ZoneT_Roof_l(a0),SplitHeight
 
 donetalking:
@@ -1647,8 +1644,8 @@ donetalking:
 
 				move.l	#ZoneBrightTable,a1
 				move.l	ZoneAdds,a2
-				move.l	PLR2_ListOfGraphRooms,a0
-; move.l PLR2_PointsToRotatePtr,a5
+				move.l	Plr2_ListOfGraphRoomsPtr_l,a0
+; move.l Plr2_PointsToRotatePtr_l,a5
 				move.l	a0,a5
 				cmp.b	#'s',mors
 				beq.s	doallz
@@ -1784,19 +1781,19 @@ findaverage:
 				beq		nosee
 
 				move.l	Plr1_RoomPtr_l,FromRoom
-				move.l	PLR2_Roompt,ToRoom
-				move.w	p1_xoff,Viewerx
-				move.w	p1_zoff,Viewerz
-				move.l	p1_yoff,d0
+				move.l	Plr2_RoomPtr_l,ToRoom
+				move.w	Plr1_TmpXOff_l,Viewerx
+				move.w	Plr1_TmpZOff_l,Viewerz
+				move.l	Plr1_TmpYOff_l,d0
 				asr.l	#7,d0
 				move.w	d0,Viewery
-				move.w	p2_xoff,Targetx
-				move.w	p2_zoff,Targetz
-				move.l	p2_yoff,d0
+				move.w	Plr2_TmpXOff_l,Targetx
+				move.w	Plr2_TmpZOff_l,Targetz
+				move.l	Plr2_TmpYOff_l,d0
 				asr.l	#7,d0
 				move.w	d0,Targety
 				move.b	Plr1_StoodInTop_b,ViewerTop
-				move.b	PLR2_StoodInTop,TargetTop
+				move.b	Plr2_StoodInTop_b,TargetTop
 				jsr		CanItBeSeen
 
 				move.l	PLR1_Obj,a0
@@ -1812,34 +1809,34 @@ nosee:
 
 
 				move.w	TempFrames,d0
-				add.w	d0,p1_holddown
-				cmp.w	#30,p1_holddown
+				add.w	d0,Plr1_TmpHoldDown_w
+				cmp.w	#30,Plr1_TmpHoldDown_w
 				blt.s	oklength
-				move.w	#30,p1_holddown
+				move.w	#30,Plr1_TmpHoldDown_w
 oklength:
 
-				tst.b	p1_fire
+				tst.b	Plr1_TmpFire_b
 				bne.s	okstillheld
-				sub.w	d0,p1_holddown
+				sub.w	d0,Plr1_TmpHoldDown_w
 				bge.s	okstillheld
-				move.w	#0,p1_holddown
+				move.w	#0,Plr1_TmpHoldDown_w
 
 okstillheld:
 
 				move.w	TempFrames,d0
-				add.w	d0,p2_holddown
+				add.w	d0,Plr2_TmpHoldDown_w
 
-				cmp.w	#30,p2_holddown
+				cmp.w	#30,Plr2_TmpHoldDown_w
 				blt.s	oklength2
-				move.w	#30,p2_holddown
+				move.w	#30,Plr2_TmpHoldDown_w
 oklength2:
 
 
-				tst.b	p2_fire
+				tst.b	Plr2_TmpFire_b
 				bne.s	okstillheld2
-				sub.w	d0,p2_holddown
+				sub.w	d0,Plr2_TmpHoldDown_w
 				bge.s	okstillheld2
-				move.w	#0,p2_holddown
+				move.w	#0,Plr2_TmpHoldDown_w
 okstillheld2:
 
 ***** CHECKING LIGHT *********
@@ -1856,10 +1853,10 @@ okstillheld2:
 ******************************
 
 ; move.l #PLR1_GunData,a1
-; move.w p1_holddown,d0
+; move.w Plr1_TmpHoldDown_w,d0
 ; move.w #50,10+32*3(a1)
 ; move.l #PLR2_GunData,a1
-; move.w p2_holddown,d0
+; move.w Plr2_TmpHoldDown_w,d0
 ; move.w #50,10+32*3(a1)
 
 ******************************************
@@ -1871,25 +1868,25 @@ okstillheld2:
 noze:
 
 				move.w	Plr1_XOff_l,d0
-				sub.w	OLDX1,d0
+				sub.w	OldX1_l,d0
 				asl.w	#4,d0
 				ext.l	d0
 				divs	d1,d0
 				move.w	d0,XDIFF1
-				move.w	PLR2_xoff,d0
-				sub.w	OLDX2,d0
+				move.w	Plr2_XOff_l,d0
+				sub.w	OldX2_l,d0
 				asl.w	#4,d0
 				ext.l	d0
 				divs	d1,d0
 				move.w	d0,XDIFF2
 				move.w	Plr1_ZOff_l,d0
-				sub.w	OLDZ1,d0
+				sub.w	OldZ1_l,d0
 				asl.w	#4,d0
 				ext.l	d0
 				divs	d1,d0
 				move.w	d0,ZDIFF1
-				move.w	PLR2_zoff,d0
-				sub.w	OLDZ2,d0
+				move.w	Plr2_ZOff_l,d0
+				sub.w	OldZ2_l,d0
 				asl.w	#4,d0
 				ext.l	d0
 				divs	d1,d0
@@ -2016,19 +2013,19 @@ IWasPlayer1:
 drawplayer2
 
 				move.w	#0,scaleval
-				move.l	PLR2_xoff,xoff
-				move.l	PLR2_yoff,yoff
-				move.l	PLR2_zoff,zoff
-				move.w	PLR2_angpos,angpos
-				move.w	PLR2_cosval,cosval
-				move.w	PLR2_sinval,sinval
+				move.l	Plr2_XOff_l,xoff
+				move.l	Plr2_YOff_l,yoff
+				move.l	Plr2_ZOff_l,zoff
+				move.w	Plr2_AngPos_w,angpos
+				move.w	Plr2_CosVal_w,cosval
+				move.w	Plr2_SinVal_w,sinval
 
 
 
-				move.l	PLR2_ListOfGraphRooms,ListOfGraphRooms
-				move.l	PLR2_PointsToRotatePtr,PointsToRotatePtr
-				move.b	PLR2_Echo,PLREcho
-				move.l	PLR2_Roompt,Roompt
+				move.l	Plr2_ListOfGraphRoomsPtr_l,ListOfGraphRooms
+				move.l	Plr2_PointsToRotatePtr_l,PointsToRotatePtr
+				move.b	Plr2_Echo_b,PLREcho
+				move.l	Plr2_RoomPtr_l,Roompt
 
 				move.l	#KeyMap,a5
 				moveq	#0,d5
@@ -2159,7 +2156,7 @@ notdoubwidth:
 notdoubwidth2:
 
 *****************************************
-				move.l	PLR2_Roompt,a0
+				move.l	Plr2_RoomPtr_l,a0
 				move.l	#WorkSpace,a1
 				clr.l	(a1)
 				clr.l	4(a1)
@@ -3235,16 +3232,16 @@ USEPLR1:
 				beq.s	.notwist
 				move.w	d2,d4
 .notwist:
-				add.w	d3,Plr1_AltXSpdVal_l
+				add.w	d3,Plr1_SnapXSpdVal_l
 				move.w	EntT_ImpactZ_w(a0),d3
 				beq.s	.notwist2
 				move.w	d2,d4
 .notwist2:
-				add.w	d3,Plr1_AltZSpdVal_l
+				add.w	d3,Plr1_SnapZSpdVal_l
 				move.w	EntT_ImpactY_w(a0),d3
 				ext.l	d3
 				asl.l	#8,d3
-				add.l	d3,Plr1_AltYVel_l
+				add.l	d3,Plr1_SnapYVel_l
 
 				move.w	#0,EntT_ImpactX_w(a0)
 				move.w	#0,EntT_ImpactY_w(a0)
@@ -3254,7 +3251,7 @@ USEPLR1:
 				muls	d4,d0
 				asr.l	#8,d0
 				asr.l	#4,d0
-				add.w	d0,Plr1_AltAngSpd_w
+				add.w	d0,Plr1_SnapAngSpd_w
 
 				move.l	#7*2116,hitcol
 				sub.w	d2,PLAYERONEHEALTH
@@ -3273,7 +3270,7 @@ USEPLR1:
 				move.b	#0,EntT_DamageTaken_b(a0)
 				move.b	#10,EntT_NumLives_b(a0)
 
-				move.w	p1_angpos,EntT_CurrentAngle_w(a0)
+				move.w	Plr1_TmpAngPos_w,EntT_CurrentAngle_w(a0)
 				move.b	Plr1_StoodInTop_b,ShotT_InUpperZone_b(a0)
 
 				move.w	(a1),12(a0)
@@ -3288,8 +3285,8 @@ USEPLR1:
 				move.w	d2,2(a0)
 
 
-				move.l	p1_yoff,d0
-				move.l	p1_height,d1
+				move.l	Plr1_TmpYOff_l,d0
+				move.l	Plr1_TmpHeight_l,d1
 				asr.l	#1,d1
 				add.l	d1,d0
 				asr.l	#7,d0
@@ -3306,14 +3303,14 @@ USEPLR1:
 				move.l	PLR2_Obj,a0
 				move.b	#5,16(a0)
 
-				move.w	p2_angpos,d0
+				move.w	Plr2_TmpAngPos_w,d0
 				and.w	#8190,d0
 				move.w	d0,EntT_CurrentAngle_w(a0)
 ;
 ; jsr ViewpointToDraw
 ; asl.w #2,d0
 ; moveq #0,d1
-; move.b p2_bobble,d1
+; move.b Plr2_TmpBobble_w,d1
 ; not.b d1
 ; lsr.b #3,d1
 ; and.b #$3,d1
@@ -3325,21 +3322,21 @@ USEPLR1:
 				move.l	ObjectPoints,a1
 				move.l	#ObjRotated,a2
 				move.w	(a0),d0
-				move.l	PLR2_xoff,(a1,d0.w*8)
-				move.l	PLR2_zoff,4(a1,d0.w*8)
-				move.l	PLR2_Roompt,a1
+				move.l	Plr2_XOff_l,(a1,d0.w*8)
+				move.l	Plr2_ZOff_l,4(a1,d0.w*8)
+				move.l	Plr2_RoomPtr_l,a1
 
 				moveq	#0,d2
 				move.b	EntT_DamageTaken_b(a0),d2
 				beq		.notbeenshot2
 				move.w	EntT_ImpactX_w(a0),d3
-				add.w	d3,PLR2s_xspdval
+				add.w	d3,Plr2_SnapXSpdVal_l
 				move.w	EntT_ImpactZ_w(a0),d3
-				add.w	d3,PLR2s_zspdval
+				add.w	d3,Plr2_SnapZSpdVal_l
 				move.w	EntT_ImpactY_w(a0),d3
 				ext.l	d3
 				asl.l	#8,d3
-				add.l	d3,PLR2s_yvel
+				add.l	d3,Plr2_SnapYVel_l
 
 				move.w	#0,EntT_ImpactX_w(a0)
 				move.w	#0,EntT_ImpactY_w(a0)
@@ -3352,21 +3349,21 @@ USEPLR1:
 				move.b	#0,EntT_DamageTaken_b(a0)
 				move.b	#10,EntT_NumLives_b(a0)
 
-				move.b	PLR2_StoodInTop,ShotT_InUpperZone_b(a0)
+				move.b	Plr2_StoodInTop_b,ShotT_InUpperZone_b(a0)
 
 				move.w	(a1),12(a0)
 				move.w	(a1),d2
 				move.l	#ZoneBrightTable,a1
 				move.l	(a1,d2.w*4),d2
-				tst.b	PLR2_StoodInTop
+				tst.b	Plr2_StoodInTop_b
 				bne.s	.okinbott2
 				swap	d2
 .okinbott2:
 
 				move.w	d2,2(a0)
 
-				move.l	p2_yoff,d0
-				move.l	p2_height,d1
+				move.l	Plr2_TmpYOff_l,d0
+				move.l	Plr2_TmpHeight_l,d1
 				asr.l	#1,d1
 				add.l	d1,d0
 				asr.l	#7,d0
@@ -3484,7 +3481,7 @@ USEPLR1:
 				move.w	(a1),EntT_GraphicRoom_w+128(a0)
 
 				moveq	#0,d0
-				move.b	p1_gunselected,d0
+				move.b	Plr1_TmpGunSelected_b,d0
 
 				move.l	GLF_DatabasePtr_l,a1
 				add.l	#GLFT_GunObjects_l,a1
@@ -3501,8 +3498,8 @@ USEPLR1:
 
 				st		EntT_WhichAnim_b+128(a0)
 
-				move.l	p1_yoff,d0
-				move.l	p1_height,d1
+				move.l	Plr1_TmpYOff_l,d0
+				move.l	Plr1_TmpHeight_l,d1
 				asr.l	#2,d1
 				add.l	#10*128,d1
 				add.l	d1,d0
@@ -3531,9 +3528,9 @@ USEPLR2:
 				move.l	ObjectPoints,a1
 				move.l	#ObjRotated,a2
 				move.w	(a0),d0
-				move.l	PLR2_xoff,(a1,d0.w*8)
-				move.l	PLR2_zoff,4(a1,d0.w*8)
-				move.l	PLR2_Roompt,a1
+				move.l	Plr2_XOff_l,(a1,d0.w*8)
+				move.l	Plr2_ZOff_l,4(a1,d0.w*8)
+				move.l	Plr2_RoomPtr_l,a1
 
 				moveq	#0,d2
 				move.b	EntT_DamageTaken_b(a0),d2
@@ -3544,18 +3541,18 @@ USEPLR2:
 				beq.s	.notwist
 				move.w	d2,d4
 .notwist:
-				add.w	d3,PLR2s_xspdval
+				add.w	d3,Plr2_SnapXSpdVal_l
 				move.w	EntT_ImpactZ_w(a0),d3
 				beq.s	.notwist2
 				move.w	d2,d4
 .notwist2:
-				add.w	d3,PLR2s_zspdval
+				add.w	d3,Plr2_SnapZSpdVal_l
 
 				jsr		GetRand
 				muls	d4,d0
 				asr.l	#8,d0
 				asr.l	#4,d0
-				add.w	d0,PLR2s_angspd
+				add.w	d0,Plr2_SnapAngSpd_w
 
 				move.l	#7*2116,hitcol
 				sub.w	d2,PLAYERTWOHEALTH
@@ -3576,22 +3573,22 @@ USEPLR2:
 				move.b	#0,EntT_DamageTaken_b(a0)
 				move.b	#10,EntT_NumLives_b(a0)
 
-				move.w	p2_angpos,EntT_CurrentAngle_w(a0)
-				move.b	PLR2_StoodInTop,ShotT_InUpperZone_b(a0)
+				move.w	Plr2_TmpAngPos_w,EntT_CurrentAngle_w(a0)
+				move.b	Plr2_StoodInTop_b,ShotT_InUpperZone_b(a0)
 
 				move.w	(a1),12(a0)
 				move.w	(a1),d2
 				move.l	#ZoneBrightTable,a1
 				move.l	(a1,d2.w*4),d2
-				tst.b	PLR2_StoodInTop
+				tst.b	Plr2_StoodInTop_b
 				bne.s	.okinbott
 				swap	d2
 .okinbott:
 
 				move.w	d2,2(a0)
 
-				move.l	PLR2_yoff,d0
-				move.l	p2_height,d1
+				move.l	Plr2_YOff_l,d0
+				move.l	Plr2_TmpHeight_l,d1
 				asr.l	#1,d1
 				add.l	d1,d0
 				asr.l	#7,d0
@@ -3614,7 +3611,7 @@ USEPLR2:
 ; jsr ViewpointToDraw
 ; asl.w #2,d0
 ; moveq #0,d1
-; move.b p2_bobble,d1
+; move.b Plr2_TmpBobble_w,d1
 ; not.b d1
 ; lsr.b #3,d1
 ; and.b #$3,d1
@@ -3635,9 +3632,9 @@ USEPLR2:
 				beq		.notbeenshot2
 
 				move.w	EntT_ImpactX_w(a0),d3
-				add.w	d3,Plr1_AltXSpdVal_l
+				add.w	d3,Plr1_SnapXSpdVal_l
 				move.w	EntT_ImpactZ_w(a0),d3
-				add.w	d3,Plr1_AltZSpdVal_l
+				add.w	d3,Plr1_SnapZSpdVal_l
 
 				sub.w	d2,PLAYERONEHEALTH
 
@@ -3659,8 +3656,8 @@ USEPLR2:
 
 				move.w	d2,2(a0)
 
-				move.l	p1_yoff,d0
-				move.l	p1_height,d1
+				move.l	Plr1_TmpYOff_l,d0
+				move.l	Plr1_TmpHeight_l,d1
 				asr.l	#1,d1
 				add.l	d1,d0
 				asr.l	#7,d0
@@ -3763,7 +3760,7 @@ USEPLR2:
 				rts
 
 .notdead:
-				move.l	PLR2_Roompt,a1
+				move.l	Plr2_RoomPtr_l,a1
 
 				move.w	EntT_CurrentAngle_w(a0),d0
 				add.w	#4096,d0
@@ -3774,7 +3771,7 @@ USEPLR2:
 				move.w	(a1),EntT_GraphicRoom_w+64(a0)
 
 				moveq	#0,d0
-				move.b	p2_gunselected,d0
+				move.b	Plr2_TmpGunSelected_b,d0
 
 				move.l	GLF_DatabasePtr_l,a1
 				add.l	#GLFT_GunObjects_l,a1
@@ -3791,8 +3788,8 @@ USEPLR2:
 
 				st		EntT_WhichAnim_b+64(a0)
 
-				move.l	p2_yoff,d0
-				move.l	p2_height,d1
+				move.l	Plr2_TmpYOff_l,d0
+				move.l	Plr2_TmpHeight_l,d1
 				asr.l	#2,d1
 				add.l	#10*128,d1
 				add.l	d1,d0
@@ -3846,20 +3843,20 @@ PLR1_Control:
 				move.l	d2,oldx
 				move.l	Plr1_ZOff_l,d3
 				move.l	d3,oldz
-				move.l	p1_xoff,d0
+				move.l	Plr1_TmpXOff_l,d0
 				move.l	d0,Plr1_XOff_l
 				move.l	d0,newx
-				move.l	p1_zoff,d1
+				move.l	Plr1_TmpZOff_l,d1
 				move.l	d1,newz
 				move.l	d1,Plr1_ZOff_l
 
-				move.l	p1_height,Plr1_Height_l
+				move.l	Plr1_TmpHeight_l,Plr1_Height_l
 
 				sub.l	d2,d0
 				sub.l	d3,d1
 				move.l	d0,xdiff
 				move.l	d1,zdiff
-				move.w	p1_angpos,d0
+				move.w	Plr1_TmpAngPos_w,d0
 				move.w	d0,Plr1_AngPos_w
 
 				move.l	#SineTable,a1
@@ -3868,8 +3865,8 @@ PLR1_Control:
 				and.w	#8190,d0
 				move.w	(a1,d0.w),Plr1_CosVal_w
 
-				move.l	p1_yoff,d0
-				move.w	p1_bobble,d1
+				move.l	Plr1_TmpYOff_l,d0
+				move.w	Plr1_TmpBobble_w,d1
 				move.w	(a1,d1.w),d1
 				move.w	d1,d3
 				ble.s	.notnegative
@@ -3960,11 +3957,11 @@ PLR1_Control:
 				add.l	LEVELDATA,a0
 				move.l	a0,Plr1_RoomPtr_l
 				add.l	ZoneT_Floor_l(a0),d1
-				move.l	d1,Plr1_AltYOff_l
+				move.l	d1,Plr1_SnapYOff_l
 				move.l	d1,Plr1_YOff_l
-				move.l	d1,Plr1_AltTYOff_l
-				move.l	Plr1_XOff_l,Plr1_AltXOff_l
-				move.l	Plr1_ZOff_l,Plr1_AltZOff_l
+				move.l	d1,Plr1_SnapTYOff_l
+				move.l	Plr1_XOff_l,Plr1_SnapXOff_l
+				move.l	Plr1_ZOff_l,Plr1_SnapZOff_l
 
 				SAVEREGS
 				move.w	#0,Noisex
@@ -3992,8 +3989,8 @@ PLR1_Control:
 				beq.s	.nothitanything
 				move.w	oldx,Plr1_XOff_l
 				move.w	oldz,Plr1_ZOff_l
-				move.l	Plr1_XOff_l,Plr1_AltXOff_l
-				move.l	Plr1_ZOff_l,Plr1_AltZOff_l
+				move.l	Plr1_XOff_l,Plr1_SnapXOff_l
+				move.l	Plr1_ZOff_l,Plr1_SnapZOff_l
 				bra		.cantmove
 .nothitanything:
 
@@ -4007,8 +4004,8 @@ PLR1_Control:
 				move.l	objroom,Plr1_RoomPtr_l
 				move.w	newx,Plr1_XOff_l
 				move.w	newz,Plr1_ZOff_l
-				move.l	Plr1_XOff_l,Plr1_AltXOff_l
-				move.l	Plr1_ZOff_l,Plr1_AltZOff_l
+				move.l	Plr1_XOff_l,Plr1_SnapXOff_l
+				move.l	Plr1_ZOff_l,Plr1_SnapZOff_l
 
 .cantmove:
 
@@ -4022,8 +4019,8 @@ notintop:
 
 				adda.w	#ZoneT_Points_w,a0
 				sub.l	Plr1_Height_l,d0
-				move.l	d0,Plr1_AltTYOff_l
-				move.w	p1_angpos,tmpangpos
+				move.l	d0,Plr1_SnapTYOff_l
+				move.w	Plr1_TmpAngPos_w,tmpangpos
 
 ; move.l (a0),a0		; jump to viewpoint list
 * A0 is pointing at a pointer to list of points to rotate
@@ -4058,36 +4055,36 @@ PLR2_Control:
 
 ; Take a snapshot of everything.
 
-				move.l	PLR2_xoff,d2
-				move.l	d2,PLR2_oldxoff
-				move.l	d2,oldx
-				move.l	PLR2_zoff,d3
-				move.l	d3,PLR2_oldzoff
-				move.l	d3,oldz
-				move.l	p2_xoff,d0
-				move.l	d0,PLR2_xoff
-				move.l	d0,newx
-				move.l	p2_zoff,d1
-				move.l	d1,newz
-				move.l	d1,PLR2_zoff
+				move.l	Plr2_XOff_l,d2
 
-				move.l	p2_height,PLR2_height
+				move.l	d2,oldx
+				move.l	Plr2_ZOff_l,d3
+
+				move.l	d3,oldz
+				move.l	Plr2_TmpXOff_l,d0
+				move.l	d0,Plr2_XOff_l
+				move.l	d0,newx
+				move.l	Plr2_TmpZOff_l,d1
+				move.l	d1,newz
+				move.l	d1,Plr2_ZOff_l
+
+				move.l	Plr2_TmpHeight_l,Plr2_Height_l
 
 				sub.l	d2,d0
 				sub.l	d3,d1
 				move.l	d0,xdiff
 				move.l	d1,zdiff
-				move.w	p2_angpos,d0
-				move.w	d0,PLR2_angpos
+				move.w	Plr2_TmpAngPos_w,d0
+				move.w	d0,Plr2_AngPos_w
 
 				move.l	#SineTable,a1
-				move.w	(a1,d0.w),PLR2_sinval
+				move.w	(a1,d0.w),Plr2_SinVal_w
 				add.w	#2048,d0
 				and.w	#8190,d0
-				move.w	(a1,d0.w),PLR2_cosval
+				move.w	(a1,d0.w),Plr2_CosVal_w
 
-				move.l	p2_yoff,d0
-				move.w	p2_bobble,d1
+				move.l	Plr2_TmpYOff_l,d0
+				move.w	Plr2_TmpBobble_w,d1
 				move.w	(a1,d1.w),d1
 				move.w	d1,d3
 				ble.s	.notnegative
@@ -4106,7 +4103,7 @@ PLR2_Control:
 
 				move.l	d1,PLR2_BOBBLEY
 
-				move.l	PLR2_height,d4
+				move.l	Plr2_Height_l,d4
 				sub.l	d1,d4
 				add.l	d1,d0
 
@@ -4115,9 +4112,9 @@ PLR2_Control:
 				asr.w	#6,d3
 				ext.l	d3
 				move.l	d3,xwobble
-				move.w	PLR2_sinval,d1
+				move.w	Plr2_SinVal_w,d1
 				muls	d3,d1
-				move.w	PLR2_cosval,d2
+				move.w	Plr2_CosVal_w,d2
 				muls	d3,d2
 				swap	d1
 				swap	d2
@@ -4128,7 +4125,7 @@ PLR2_Control:
 				move.w	d2,xwobzoff
 .otherwob
 
-				move.l	d0,PLR2_yoff
+				move.l	d0,Plr2_YOff_l
 				move.l	d0,newy
 				move.l	d0,oldy
 
@@ -4144,7 +4141,7 @@ PLR2_Control:
 
 				move.l	#$1000000,StepDownVal
 
-				move.l	PLR2_Roompt,a0
+				move.l	Plr2_RoomPtr_l,a0
 				move.w	ZoneT_TelZone_w(a0),d0
 				blt		.noteleport
 
@@ -4157,30 +4154,30 @@ PLR2_Control:
 				tst.b	hitwall
 				beq.s	.teleport
 
-				move.w	PLR2_xoff,newx
-				move.w	PLR2_zoff,newz
+				move.w	Plr2_XOff_l,newx
+				move.w	Plr2_ZOff_l,newz
 				bra		.noteleport
 
 .teleport:
 
 				st		Plr2_Teleported_b
 
-				move.l	PLR2_Roompt,a0
+				move.l	Plr2_RoomPtr_l,a0
 				move.w	ZoneT_TelZone_w(a0),d0
-				move.w	ZoneT_TelX_w(a0),PLR2_xoff
-				move.w	ZoneT_TelZ_w(a0),PLR2_zoff
-				move.l	PLR2_yoff,d1
+				move.w	ZoneT_TelX_w(a0),Plr2_XOff_l
+				move.w	ZoneT_TelZ_w(a0),Plr2_ZOff_l
+				move.l	Plr2_YOff_l,d1
 				sub.l	ZoneT_Floor_l(a0),d1
 				move.l	ZoneAdds,a0
 				move.l	(a0,d0.w*4),a0
 				add.l	LEVELDATA,a0
-				move.l	a0,PLR2_Roompt
+				move.l	a0,Plr2_RoomPtr_l
 				add.l	ZoneT_Floor_l(a0),d1
-				move.l	d1,PLR2s_yoff
-				move.l	d1,PLR2_yoff
-				move.l	d1,PLR2s_tyoff
-				move.l	PLR2_xoff,PLR2s_xoff
-				move.l	PLR2_zoff,PLR2s_zoff
+				move.l	d1,Plr2_SnapYOff_l
+				move.l	d1,Plr2_YOff_l
+				move.l	d1,Plr2_SnapTYOff_l
+				move.l	Plr2_XOff_l,Plr2_SnapXOff_l
+				move.l	Plr2_ZOff_l,Plr2_SnapZOff_l
 
 				SAVEREGS
 				move.w	#0,Noisex
@@ -4195,9 +4192,9 @@ PLR2_Control:
 
 .noteleport:
 
-				move.l	PLR2_Roompt,objroom
+				move.l	Plr2_RoomPtr_l,objroom
 				move.w	#%100000000000,wallflags
-				move.b	PLR2_StoodInTop,StoodInTop
+				move.b	Plr2_StoodInTop_b,StoodInTop
 
 				move.l	#%1011111010111100011,CollideFlags
 				move.l	PLR2_Obj,a0
@@ -4206,10 +4203,10 @@ PLR2_Control:
 				jsr		Collision
 				tst.b	hitwall
 				beq.s	.nothitanything
-				move.w	oldx,PLR2_xoff
-				move.w	oldz,PLR2_zoff
-				move.l	PLR2_xoff,PLR2s_xoff
-				move.l	PLR2_zoff,PLR2s_zoff
+				move.w	oldx,Plr2_XOff_l
+				move.w	oldz,Plr2_ZOff_l
+				move.l	Plr2_XOff_l,Plr2_SnapXOff_l
+				move.l	Plr2_ZOff_l,Plr2_SnapZOff_l
 				bra		.cantmove
 .nothitanything:
 
@@ -4219,34 +4216,34 @@ PLR2_Control:
 				clr.b	exitfirst
 				clr.b	wallbounce
 				bsr		MoveObject
-				move.b	StoodInTop,PLR2_StoodInTop
-				move.l	objroom,PLR2_Roompt
-				move.w	newx,PLR2_xoff
-				move.w	newz,PLR2_zoff
-				move.l	PLR2_xoff,PLR2s_xoff
-				move.l	PLR2_zoff,PLR2s_zoff
+				move.b	StoodInTop,Plr2_StoodInTop_b
+				move.l	objroom,Plr2_RoomPtr_l
+				move.w	newx,Plr2_XOff_l
+				move.w	newz,Plr2_ZOff_l
+				move.l	Plr2_XOff_l,Plr2_SnapXOff_l
+				move.l	Plr2_ZOff_l,Plr2_SnapZOff_l
 
 .cantmove
 
-				move.l	PLR2_Roompt,a0
+				move.l	Plr2_RoomPtr_l,a0
 
 				move.l	ZoneT_Floor_l(a0),d0
-				tst.b	PLR2_StoodInTop
+				tst.b	Plr2_StoodInTop_b
 				beq.s	.notintop
 				move.l	ZoneT_UpperFloor_l(a0),d0
 .notintop:
 
 				adda.w	#ZoneT_Points_w,a0
-				sub.l	PLR2_height,d0
-				move.l	d0,PLR2s_tyoff
-				move.w	p2_angpos,tmpangpos
+				sub.l	Plr2_Height_l,d0
+				move.l	d0,Plr2_SnapTYOff_l
+				move.w	Plr2_TmpAngPos_w,tmpangpos
 
 ; move.l (a0),a0		; jump to viewpoint list
 * A0 is pointing at a pointer to list of points to rotate
 				move.w	(a0)+,d1
 				ext.l	d1
-				add.l	PLR2_Roompt,d1
-				move.l	d1,PLR2_PointsToRotatePtr
+				add.l	Plr2_RoomPtr_l,d1
+				move.l	d1,Plr2_PointsToRotatePtr_l
 				tst.b	(a0)+
 				sne		DRAWNGRAPHTOP
 				beq.s	.nobackgraphics
@@ -4257,10 +4254,10 @@ PLR2_Control:
 				move.l	(a7)+,a0
 .nobackgraphics:
 
-				move.b	(a0)+,PLR2_Echo
+				move.b	(a0)+,Plr2_Echo_b
 
 				adda.w	#10,a0
-				move.l	a0,PLR2_ListOfGraphRooms
+				move.l	a0,Plr2_ListOfGraphRoomsPtr_l
 
 *****************************************************
 				rts
@@ -4547,7 +4544,7 @@ jumpoutofrooms:
 				beq.s	drawslavegun
 
 				moveq	#0,d0
-				move.b	Plr1_GunSelected_w,d0
+				move.b	Plr1_GunSelected_b,d0
 				moveq	#0,d1
 				move.b	PLR1_GunFrame,d1
 ; bsr DRAWINGUN
@@ -4555,7 +4552,7 @@ jumpoutofrooms:
 
 drawslavegun
 				moveq	#0,d0
-				move.b	PLR2_GunSelected,d0
+				move.b	Plr2_GunSelected_b,d0
 				moveq	#0,d1
 				move.b	PLR2_GunFrame,d1
 ; bsr DRAWINGUN
@@ -5382,8 +5379,8 @@ CalcPLR1InLine:
 
 CalcPLR2InLine:
 
-				move.w	PLR2_sinval,d5
-				move.w	PLR2_cosval,d6
+				move.w	Plr2_SinVal_w,d5
+				move.w	Plr2_CosVal_w,d6
 				move.l	ObjectData,a4
 				move.l	ObjectPoints,a0
 				move.w	NumObjectPoints,d7
@@ -5396,7 +5393,7 @@ CalcPLR2InLine:
 				beq.s	.itaux
 
 				move.w	(a0),d0
-				sub.w	PLR2_xoff,d0
+				sub.w	Plr2_XOff_l,d0
 				move.w	4(a0),d1
 				addq	#8,a0
 
@@ -5408,7 +5405,7 @@ CalcPLR2InLine:
 ; move.l #ColBoxTable,a6
 ; lea (a6,d2.w*8),a6
 
-				sub.w	PLR2_zoff,d1
+				sub.w	Plr2_ZOff_l,d1
 				move.w	d0,d2
 				muls	d6,d2
 				move.w	d1,d3
@@ -5704,12 +5701,12 @@ AmmoBar:
 * Do guns first.
 
 				move.l	#borderchars,a4
-				move.b	p1_gunselected,d0
+				move.b	Plr1_TmpGunSelected_b,d0
 				move.l	#PLAYERONEGUNS,a5
 				cmp.b	#'s',mors
 				bne.s	.notplr2
 				move.l	#PLAYERTWOGUNS,a5
-				move.b	p2_gunselected,d0
+				move.b	Plr2_TmpGunSelected_b,d0
 .notplr2:
 
 				move.b	d0,gunny
@@ -9890,12 +9887,12 @@ dosomething:
 
 .okinbot:
 				; Issue #1 - Check we are on the floor or swimming before applying any floor damage.
-				cmp.l	Plr1_AltYOff_l,d2
+				cmp.l	Plr1_SnapYOff_l,d2
 				blt.b   .in_toxic_liquid1
 
 				; Player not in liquid, check if on floor.
-				move.l	Plr1_AltTYOff_l,d1
-				cmp.l	Plr1_AltYOff_l,d1
+				move.l	Plr1_SnapTYOff_l,d1
+				cmp.l	Plr1_SnapYOff_l,d1
 				bgt.b	.not_on_floor1
 
 .in_toxic_liquid1:
@@ -9906,21 +9903,21 @@ dosomething:
 				add.b	d0,EntT_DamageTaken_b(a0)
 
 .not_on_floor1:
-				move.l	PLR2_Roompt,a0
+				move.l	Plr2_RoomPtr_l,a0
 				move.l	ZoneT_Water_l(a0),d2      ; Water depth in d2
 				move.w	ZoneT_FloorNoise_w(a0),d0
-				tst.b	PLR2_StoodInTop
+				tst.b	Plr2_StoodInTop_b
 				beq.s	.okinbot2
 				move.w	ZoneT_UpperFloorNoise_w(a0),d0
 
 .okinbot2:
 				; Issue #1 - Check we are on the floor or swimming before applying any floor damage.
-				cmp.l	PLR2s_yoff,d2
+				cmp.l	Plr2_SnapYOff_l,d2
 				blt.b   .in_toxic_liquid2
 
 				; Player not in liquid, check if on floor.
-				move.l	PLR2s_tyoff,d1
-				cmp.l	PLR2s_yoff,d1
+				move.l	Plr2_SnapTYOff_l,d1
+				cmp.l	Plr2_SnapYOff_l,d1
 				bgt.b	.not_on_floor2
 
 .in_toxic_liquid2:
@@ -10376,7 +10373,7 @@ nostartalan:
 				clr.b	PLR1_fire
 				clr.b	PLR1_clicked
 				move.w	#0,ADDTOBOBBLE
-				move.l	#playercrouched,Plr1_AltHeight_l
+				move.l	#playercrouched,Plr1_SnapHeight_l
 				move.w	#-80,d0					; Is this related to render buffer height
 				move.w	d0,STOPOFFSET
 				neg.w	d0
@@ -10386,8 +10383,8 @@ nostartalan:
 				move.l	d0,SBIGMIDDLEY
 				jsr		PLR1_fall
 
-				move.l	Plr1_AltXSpdVal_l,d6
-				move.l	Plr1_AltZSpdVal_l,d7
+				move.l	Plr1_SnapXSpdVal_l,d6
+				move.l	Plr1_SnapZSpdVal_l,d7
 
 				tst.b	SLOWDOWN
 				beq.s	.nofriction
@@ -10410,16 +10407,16 @@ nostartalan:
 				asr.l	#3,d7
 .bug2:
 
-				add.l	d6,Plr1_AltXSpdVal_l
-				add.l	d7,Plr1_AltZSpdVal_l
+				add.l	d6,Plr1_SnapXSpdVal_l
+				add.l	d7,Plr1_SnapZSpdVal_l
 
 .nofriction:
-				move.l	Plr1_AltXSpdVal_l,d6
-				move.l	Plr1_AltZSpdVal_l,d7
-				add.l	d6,Plr1_AltXOff_l
-				add.l	d7,Plr1_AltZOff_l
+				move.l	Plr1_SnapXSpdVal_l,d6
+				move.l	Plr1_SnapZSpdVal_l,d7
+				add.l	d6,Plr1_SnapXOff_l
+				add.l	d7,Plr1_SnapZOff_l
 
-				move.w	Plr1_AltAngSpd_w,d3
+				move.w	Plr1_SnapAngSpd_w,d3
 				tst.b	SLOWDOWN
 				beq.s	.nofric
 				asr.w	#2,d3
@@ -10428,10 +10425,10 @@ nostartalan:
 .nneg:
 .nofric:
 
-				move.w	d3,Plr1_AltAngSpd_w
-				add.w	d3,Plr1_AltAngPos_w
-				add.w	d3,Plr1_AltAngPos_w
-				and.w	#8190,Plr1_AltAngPos_w
+				move.w	d3,Plr1_SnapAngSpd_w
+				add.w	d3,Plr1_SnapAngPos_w
+				add.w	d3,Plr1_SnapAngPos_w
+				and.w	#8190,Plr1_SnapAngPos_w
 
 				bra		nocontrols
 
@@ -10464,7 +10461,7 @@ control2:
 				move.w	#-1,12+128(a0)
 				clr.b	PLR2_fire
 				move.w	#0,ADDTOBOBBLE
-				move.l	#playercrouched,PLR2s_height
+				move.l	#playercrouched,Plr2_SnapHeight_l
 				move.w	#-80,d0
 				move.w	d0,STOPOFFSET
 				neg.w	d0
@@ -10475,8 +10472,8 @@ control2:
 
 				jsr		PLR2_fall
 
-				move.l	PLR2s_xspdval,d6
-				move.l	PLR2s_zspdval,d7
+				move.l	Plr2_SnapXSpdVal_l,d6
+				move.l	Plr2_SnapZSpdVal_l,d7
 
 				tst.b	SLOWDOWN
 				beq.s	.nofriction
@@ -10499,16 +10496,16 @@ control2:
 				asr.l	#3,d7
 .bug2:
 
-				add.l	d6,PLR2s_xspdval
-				add.l	d7,PLR2s_zspdval
+				add.l	d6,Plr2_SnapXSpdVal_l
+				add.l	d7,Plr2_SnapZSpdVal_l
 
 .nofriction:
-				move.l	PLR2s_xspdval,d6
-				move.l	PLR2s_zspdval,d7
-				add.l	d6,PLR2s_xoff
-				add.l	d7,PLR2s_zoff
+				move.l	Plr2_SnapXSpdVal_l,d6
+				move.l	Plr2_SnapZSpdVal_l,d7
+				add.l	d6,Plr2_SnapXOff_l
+				add.l	d7,Plr2_SnapZOff_l
 
-				move.w	PLR2s_angspd,d3
+				move.w	Plr2_SnapAngSpd_w,d3
 				tst.b	SLOWDOWN
 				beq.s	.nofric
 				asr.w	#2,d3
@@ -10517,10 +10514,10 @@ control2:
 
 .nneg:
 .nofric:
-				move.w	d3,PLR2s_angspd
-				add.w	d3,PLR2s_angpos
-				add.w	d3,PLR2s_angpos
-				and.w	#8190,PLR2s_angpos
+				move.w	d3,Plr2_SnapAngSpd_w
+				add.w	d3,Plr2_SnapAngPos_w
+				add.w	d3,Plr2_SnapAngPos_w
+				and.w	#8190,Plr2_SnapAngPos_w
 				bra.s	nocontrols
 
 .propercontrol:
@@ -11996,6 +11993,8 @@ xspdval:		dc.l	0
 zspdval:		dc.l	0
 Zone:			dc.w	0
 
+; // READY PLAYER ONE /////////////////////////////////////////////////////////////////////
+
 ; Player data definiton - TODO remove unused, tighten definitions, fix alignments
 PLR1:			dc.b	$ff
 				CNOP 0, 4
@@ -12011,7 +12010,6 @@ Plr1_Height_l:				dc.l	0
 
 ; word aligned fields next
 Plr1_Energy_w:				dc.w	191
-Plr1_GunSelected_w: 		dc.w	0
 Plr1_CosVal_w:				dc.w	0
 Plr1_SinVal_w:				dc.w	0
 Plr1_AngPos_w:				dc.w	0
@@ -12020,128 +12018,141 @@ Plr1_FloorSpd_w:			dc.w	0
 Plr1_RoomBright_w: 			dc.w	0
 
 ; byte aligned fields next
+Plr1_GunSelected_b: 		dc.b	0
 Plr1_StoodInTop_b: 			dc.b	0
-Plr1_Teleported_b:			dc.b	0 ; delcared as word, accessed as byte
-Plr1_Echo_b:				dc.b	0 ; declared as word, accessed as byte
+Plr1_Teleported_b:			dc.b	0
+Plr1_Echo_b:				dc.b	0
+
+				CNOP 0,4
+; Player 1 snapshot data, long aligned first
+Plr1_SnapXOff_l:			dc.l	0
+Plr1_SnapYOff_l:			dc.l	0
+Plr1_SnapYVel_l:			dc.l	0
+Plr1_SnapZOff_l:			dc.l	0
+Plr1_SnapTYOff_l:			dc.l	0
+Plr1_SnapXSpdVal_l:			dc.l	0
+Plr1_SnapZSpdVal_l:			dc.l	0
+Plr1_SnapHeight_l:			dc.l	0
+Plr1_SnapTargHeight_l: 		dc.l	0
+
+; Player 1 snapshot data, word aligned next
+Plr1_SnapCosVal_w:			dc.w	0
+Plr1_SnapSinVal_w:			dc.w	0
+Plr1_SnapAngPos_w:			dc.w	0
+Plr1_SnapAngSpd_w:			dc.w	0
+
+; Player 1 temporary data, long aligned first
+Plr1_TmpXOff_l:				dc.l	0 ; also accessed as w, todo determine correct size
+Plr1_TmpZOff_l:				dc.l	0
+Plr1_TmpYOff_l:				dc.l	0
+Plr1_TmpHeight_l:			dc.l	0
+
+; Player 1 temporary data, word aligned next
+Plr1_TmpAngPos_w:			dc.w	0
+Plr1_TmpBobble_w:			dc.w	0
+Plr1_TmpHoldDown_w:			dc.w	0
+
+; Player 1 temporary data, byte aligned last
+Plr1_TmpClicked_b:			dc.b	0
+Plr1_TmpSpcTap_b:			dc.b	0
+Plr1_TmpDucked_b:			dc.b	0
+Plr1_TmpGunSelected_b:		dc.b	0
+Plr1_TmpFire_b:				dc.b	0
+
+; // END PLAYER TWO /////////////////////////////////////////////////////////////////////
+
+
+; // READY PLAYER TWO /////////////////////////////////////////////////////////////////////
+
+PLR2:			dc.b	$ff
+				CNOP 0, 4
+; long aligned fields first
+Plr2_XOff_l:				dc.l	0
+Plr2_YOff_l:				dc.l	0
+Plr2_ZOff_l:				dc.l	0
+Plr2_RoomPtr_l:				dc.l	0
+Plr2_OldRoomPtr_l:			dc.l	0
+Plr2_PointsToRotatePtr_l:	dc.l 	0
+Plr2_ListOfGraphRoomsPtr_l: dc.l 	0
+Plr2_Height_l:				dc.l	0
+
+; word aligned fields next
+Plr2_Energy_w:				dc.w	191
+Plr2_CosVal_w:				dc.w	0
+Plr2_SinVal_w:				dc.w	0
+Plr2_AngPos_w:				dc.w	0
+Plr2_Zone_w:				dc.w	0
+Plr2_FloorSpd_w:			dc.w	0
+
+; byte aligned fields next
+Plr2_GunSelected_b:			dc.b	0
+Plr2_StoodInTop_b:			dc.b	0
+Plr2_Teleported_b:			dc.b	0
+Plr2_Echo_b:				dc.b	0
+
+				CNOP 0,4
+; Player 2 snapshot data, long aligned first
+Plr2_SnapXOff_l:			dc.l	0
+Plr2_SnapYOff_l:			dc.l	0
+Plr2_SnapYVel_l:			dc.l	0
+Plr2_SnapZOff_l:			dc.l	0
+Plr2_SnapTYOff_l:			dc.l	0
+Plr2_SnapXSpdVal_l:			dc.l	0
+Plr2_SnapZSpdVal_l:			dc.l	0
+Plr2_SnapHeight_l:			dc.l	0
+Plr2_SnapTargHeight_l:		dc.l	0
+
+; Player 2 snapshot data, word aligned next
+Plr2_SnapCosVal_w:			dc.w	0
+Plr2_SnapSinVal_w:			dc.w	0
+Plr2_SnapAngPos_w:			dc.w	0
+Plr2_SnapAngSpd_w:			dc.w	0
+
+; Player 2 temporary data, long aligned first
+Plr2_TmpXOff_l:				dc.l	0
+Plr2_TmpZOff_l:				dc.l	0
+Plr2_TmpYOff_l:				dc.l	0
+Plr2_TmpHeight_l:			dc.l	0
+
+; Player 2 temporary data, word aligned next
+Plr2_TmpAngPos_w:			dc.w	0
+Plr2_TmpBobble_w:			dc.w	0
+Plr2_TmpHoldDown_w:			dc.w	0
+
+; Player 2 temporary data, byte aligned last
+Plr2_TmpClicked_b:			dc.b	0
+Plr2_TmpSpcTap_b:			dc.b	0
+Plr2_TmpDucked_b:			dc.b	0
+Plr2_TmpGunSelected_b:		dc.b	0
+Plr2_TmpFire_b:				dc.b	0
+
+
+; // END PLAYER TWO /////////////////////////////////////////////////////////////////////
 
 				even
+
+
+PlayEcho:		dc.w	0 ; accessed as byte
+
 DOUBLEWIDTH:	dc.b	$0,0
 DOUBLEHEIGHT:	dc.b	0,0
 
-Plr2_Teleported_b: dc.w	0 ; delcared as word, accessed as byte
-
 				ds.w	4
+				CNOP 0, 4
 
-OLDX1:			dc.l	0
-OLDX2:			dc.l	0
-OLDZ1:			dc.l	0
-OLDZ2:			dc.l	0
+OldX1_l:			dc.l	0
+OldX2_l:			dc.l	0
+OldZ1_l:			dc.l	0
+OldZ2_l:			dc.l	0
 
 XDIFF1:			dc.l	0
 ZDIFF1:			dc.l	0
 XDIFF2:			dc.l	0
 ZDIFF2:			dc.l	0
 
-; Snapshot
-Plr1_AltCosVal_w:	dc.w	0
-Plr1_AltSinVal_w:	dc.w	0
-Plr1_AltAngPos_w:	dc.w	0
-Plr1_AltAngSpd_w:	dc.w	0
-Plr1_AltXOff_l:		dc.l	0
-Plr1_AltYOff_l:		dc.l	0
-Plr1_AltYVel_l:		dc.l	0
-Plr1_AltZOff_l:		dc.l	0
-Plr1_AltTYOff_l:	dc.l	0
-Plr1_AltXSpdVal_l:	dc.l	0
-Plr1_AltZSpdVal_l:	dc.l	0
-Plr1_AltHeight_l:	dc.l	0
-Plr1_AltTargHeight_l: dc.l	0
-
-
-p1_xoff:		dc.l	0
-p1_zoff:		dc.l	0
-p1_yoff:		dc.l	0
-p1_height:		dc.l	0
-p1_angpos:		dc.w	0
-p1_bobble:		dc.w	0
-p1_clicked:		dc.b	0
-p1_spctap:		dc.b	0
-p1_ducked:		dc.b	0
-p1_gunselected:	dc.b	0
-p1_fire:		dc.b	0
 				even
-p1_holddown:	dc.w	0
 
 				ds.w	4
-
-PLR2:			dc.b	$ff
-				even
-PLR2_GunSelected: dc.w	0
-PLR2_energy:	dc.w	191
-PLR2_cosval:	dc.w	0
-PLR2_sinval:	dc.w	0
-PLR2_angpos:	dc.w	0
-PLR2_angspd:	dc.w	0
-PLR2_xoff:		dc.l	0
-PLR2_yoff:		dc.l	0
-PLR2_yvel:		dc.l	0
-PLR2_zoff:		dc.l	0
-PLR2_tyoff:		dc.l	0
-PLR2_xspdval:	dc.l	0
-PLR2_zspdval:	dc.l	0
-PLR2_Zone:		dc.w	0
-PLR2_Roompt:	dc.l	0
-PLR2_OldRoompt:	dc.l	0
-PLR2_PointsToRotatePtr: dc.l 0
-PLR2_ListOfGraphRooms: dc.l 0
-PLR2_oldxoff:	dc.l	0
-PLR2_oldzoff:	dc.l	0
-PLR2_StoodInTop: dc.b	0
-				even
-PLR2_height:	dc.l	0
-PLR2_Echo:		dc.w	0
-PlayEcho:		dc.w	0
-
-Plr2_FloorSpd_l:			dc.l	0
-
-				ds.w	4
-
-PLR2s_cosval:	dc.w	0
-PLR2s_sinval:	dc.w	0
-PLR2s_angpos:	dc.w	0
-PLR2s_angspd:	dc.w	0
-PLR2s_xoff:		dc.l	0
-PLR2s_yoff:		dc.l	0
-PLR2s_yvel:		dc.l	0
-PLR2s_zoff:		dc.l	0
-PLR2s_tyoff:	dc.l	0
-PLR2s_xspdval:	dc.l	0
-PLR2s_zspdval:	dc.l	0
-PLR2s_Zone:		dc.w	0
-PLR2s_Roompt:	dc.l	0
-PLR2s_OldRoompt: dc.l	0
-PLR2s_PointsToRotatePtr: dc.l 0
-PLR2s_ListOfGraphRooms: dc.l 0
-PLR2s_oldxoff:	dc.l	0
-PLR2s_oldzoff:	dc.l	0
-PLR2s_height:	dc.l	0
-PLR2s_targheight: dc.l	0
-
-				ds.w	4
-
-p2_xoff:		dc.l	0
-p2_zoff:		dc.l	0
-p2_yoff:		dc.l	0
-p2_height:		dc.l	0
-p2_angpos:		dc.w	0
-p2_bobble:		dc.w	0
-p2_clicked:		dc.b	0
-p2_spctap:		dc.b	0
-p2_ducked:		dc.b	0
-p2_gunselected:	dc.b	0
-p2_fire:		dc.b	0
-				even
-p2_holddown:	dc.w	0
 
 liftanimtab:
 

--- a/ab3d2_source/hires.s
+++ b/ab3d2_source/hires.s
@@ -819,8 +819,8 @@ NOCLTXT:
 
 				;FIXME: need to load the game palette here?
 
-				clr.b	PLR1_Ducked
-				clr.b	PLR2_Ducked
+				clr.b	Plr1_Ducked_b
+				clr.b	Plr2_Ducked_b
 				clr.b	Plr1_TmpDucked_b
 				clr.b	Plr2_TmpDucked_b
 
@@ -1374,7 +1374,7 @@ okwat:
 				clr.b	PLR1_clicked
 				move.b	PLR1_SPCTAP,Plr1_TmpSpcTap_b
 				clr.b	PLR1_SPCTAP
-				move.b	PLR1_Ducked,Plr1_TmpDucked_b
+				move.b	Plr1_Ducked_b,Plr1_TmpDucked_b
 				move.b	Plr1_GunSelected_b,Plr1_TmpGunSelected_b
 
 				bsr		PLR1_Control
@@ -1436,7 +1436,7 @@ NotOnePlayer:
 				move.b	PLR1_fire,Plr1_TmpFire_b
 				move.b	PLR1_SPCTAP,Plr1_TmpSpcTap_b
 				clr.b	PLR1_SPCTAP
-				move.b	PLR1_Ducked,Plr1_TmpDucked_b
+				move.b	Plr1_Ducked_b,Plr1_TmpDucked_b
 				move.b	Plr1_GunSelected_b,Plr1_TmpGunSelected_b
 
 				move.l	PLR1_AIMSPD,d0
@@ -1481,7 +1481,7 @@ NotOnePlayer:
 				move.w	Rand1,d0
 				swap	d0
 				move.b	Plr1_TmpDucked_b,d0
-				or.b	PLR1_Squished,d0
+				or.b	Plr1_Squished_b,d0
 				lsl.w	#8,d0
 				move.b	Plr1_TmpGunSelected_b,d0
 				jsr		SENDFIRST
@@ -1559,7 +1559,7 @@ ASlaveShouldWaitOnHisMaster:
 				move.b	PLR2_fire,Plr2_TmpFire_b
 				move.b	PLR2_SPCTAP,Plr2_TmpSpcTap_b
 				clr.b	PLR2_SPCTAP
-				move.b	PLR2_Ducked,Plr2_TmpDucked_b
+				move.b	Plr2_Ducked_b,Plr2_TmpDucked_b
 				move.b	Plr2_GunSelected_b,Plr2_TmpGunSelected_b
 
 				move.l	PLR2_AIMSPD,d0
@@ -1602,7 +1602,7 @@ ASlaveShouldWaitOnHisMaster:
 				move.w	d0,TempFrames
 
 				move.b	Plr2_TmpDucked_b,d0
-				or.b	PLR2_Squished,d0
+				or.b	Plr2_Squished_b,d0
 				lsl.w	#8,d0
 				move.b	Plr2_TmpGunSelected_b,d0
 				jsr		RECFIRST
@@ -1872,25 +1872,23 @@ noze:
 				asl.w	#4,d0
 				ext.l	d0
 				divs	d1,d0
-				move.w	d0,XDIFF1
+				move.w	d0,XDiff_w
 				move.w	Plr2_XOff_l,d0
 				sub.w	OldX2_l,d0
 				asl.w	#4,d0
 				ext.l	d0
 				divs	d1,d0
-				move.w	d0,XDIFF2
 				move.w	Plr1_ZOff_l,d0
 				sub.w	OldZ1_l,d0
 				asl.w	#4,d0
 				ext.l	d0
 				divs	d1,d0
-				move.w	d0,ZDIFF1
+				move.w	d0,ZDiff_w
 				move.w	Plr2_ZOff_l,d0
 				sub.w	OldZ2_l,d0
 				asl.w	#4,d0
 				ext.l	d0
 				divs	d1,d0
-				move.w	d0,ZDIFF2
 
 				cmp.b	#'s',mors
 				beq.s	ImPlayer2OhYesIAm
@@ -3875,9 +3873,9 @@ PLR1_Control:
 				add.w	#16384,d1
 				asr.w	#4,d1
 
-				tst.b	PLR1_Ducked
+				tst.b	Plr1_Ducked_b
 				bne.s	.notdouble
-				tst.b	PLR1_Squished
+				tst.b	Plr1_Squished_b
 				bne.s	.notdouble
 				add.w	d1,d1
 .notdouble
@@ -3913,9 +3911,9 @@ PLR1_Control:
 
 				move.l	d4,thingheight
 				move.l	#40*256,StepUpVal
-				tst.b	PLR1_Squished
+				tst.b	Plr1_Squished_b
 				bne.s	.smallstep
-				tst.b	PLR1_Ducked
+				tst.b	Plr1_Ducked_b
 				beq.s	.okbigstep
 .smallstep
 				move.l	#10*256,StepUpVal
@@ -4093,9 +4091,9 @@ PLR2_Control:
 				add.w	#16384,d1
 				asr.w	#4,d1
 
-				tst.b	PLR2_Ducked
+				tst.b	Plr2_Ducked_b
 				bne.s	.notdouble
-				tst.b	PLR2_Squished
+				tst.b	Plr2_Squished_b
 				bne.s	.notdouble
 				add.w	d1,d1
 .notdouble
@@ -4131,9 +4129,9 @@ PLR2_Control:
 
 				move.l	d4,thingheight
 				move.l	#40*256,StepUpVal
-				tst.b	PLR2_Squished
+				tst.b	Plr2_Squished_b
 				bne.s	.smallstep
-				tst.b	PLR2_Ducked
+				tst.b	Plr2_Ducked_b
 				beq.s	.okbigstep
 .smallstep:
 				move.l	#10*256,StepUpVal
@@ -6529,9 +6527,9 @@ PLR2_fire:		dc.b	0
 * This routine animates brightnesses.
 
 
-liftpt:			dc.l	liftanimtab
+;liftpt:			dc.l	liftanimtab
 
-brightpt:
+;brightpt:
 				dc.l	brightanimtab
 
 ******************************
@@ -8364,7 +8362,7 @@ val				SET		val+4
 leftedge:		dc.w	0
 rightedge:		dc.w	0
 
-rndpt:			dc.l	rndtab
+;rndpt:			dc.l	rndtab
 
 
 dst:			dc.l	0
@@ -8408,7 +8406,6 @@ FloorLine:
 ConstCol:		dc.w	0
 
 BumpLine:
-
 				tst.b	smoothbumps
 				beq.s	Chunky
 
@@ -8417,7 +8414,6 @@ BumpLine:
 				bra		pastast
 
 Chunky:
-
 				moveq	#0,d2
 				move.l	#Bumptile,a0
 				move.w	whichtile,d2
@@ -9520,20 +9516,11 @@ OldSpace:		dc.b	0
 SpaceTapped:	dc.b	0
 PLR1_SPCTAP:	dc.b	0
 PLR2_SPCTAP:	dc.b	0
-PLR1_Ducked:	dc.b	0
-PLR2_Ducked:	dc.b	0
 				even
-
-PLR1_Squished:	dc.w	0
-PLR2_Squished:	dc.w	0
-PLR1s_SquishedHeight: dc.l 0
-PLR2s_SquishedHeight: dc.l 0
 
 				include	"plr1control.s"
 				include	"plr2control.s"
 				include	"fall.s"
-
-
 
 *******************************************8
 
@@ -11982,16 +11969,16 @@ EndBackPicture:				; FIXME: this obviously doesn't work anymore, yet is still re
 SineTable:
 				incbin	"bigsine"				; sine/cosine << 15
 
-angspd:			dc.w	0
+;angspd:			dc.w	0
 flooryoff:		dc.w	0						; viewer y pos << 6
 xoff:			dc.l	0
 zoff:			dc.l	0
 yoff:			dc.l	0
-yvel:			dc.l	0
-tyoff:			dc.l	0
-xspdval:		dc.l	0
-zspdval:		dc.l	0
-Zone:			dc.w	0
+;yvel:			dc.l	0
+;tyoff:			dc.l	0
+;xspdval:		dc.l	0
+;zspdval:		dc.l	0
+;Zone:			dc.w	0
 
 ; // READY PLAYER ONE /////////////////////////////////////////////////////////////////////
 
@@ -12021,6 +12008,8 @@ Plr1_RoomBright_w: 			dc.w	0
 Plr1_GunSelected_b: 		dc.b	0
 Plr1_StoodInTop_b: 			dc.b	0
 Plr1_Teleported_b:			dc.b	0
+Plr1_Ducked_b:				dc.b	0
+Plr1_Squished_b:			dc.b	0
 Plr1_Echo_b:				dc.b	0
 
 				CNOP 0,4
@@ -12033,6 +12022,7 @@ Plr1_SnapTYOff_l:			dc.l	0
 Plr1_SnapXSpdVal_l:			dc.l	0
 Plr1_SnapZSpdVal_l:			dc.l	0
 Plr1_SnapHeight_l:			dc.l	0
+Plr1_SnapSquishedHeight_l:	dc.l	0
 Plr1_SnapTargHeight_l: 		dc.l	0
 
 ; Player 1 snapshot data, word aligned next
@@ -12088,6 +12078,8 @@ Plr2_FloorSpd_w:			dc.w	0
 Plr2_GunSelected_b:			dc.b	0
 Plr2_StoodInTop_b:			dc.b	0
 Plr2_Teleported_b:			dc.b	0
+Plr2_Ducked_b:				dc.b	0
+Plr2_Squished_b:			dc.b	0
 Plr2_Echo_b:				dc.b	0
 
 				CNOP 0,4
@@ -12100,6 +12092,7 @@ Plr2_SnapTYOff_l:			dc.l	0
 Plr2_SnapXSpdVal_l:			dc.l	0
 Plr2_SnapZSpdVal_l:			dc.l	0
 Plr2_SnapHeight_l:			dc.l	0
+Plr2_SnapSquishedHeight_l:	dc.l	0
 Plr2_SnapTargHeight_l:		dc.l	0
 
 ; Player 2 snapshot data, word aligned next
@@ -12145,27 +12138,25 @@ OldX2_l:			dc.l	0
 OldZ1_l:			dc.l	0
 OldZ2_l:			dc.l	0
 
-XDIFF1:			dc.l	0
-ZDIFF1:			dc.l	0
-XDIFF2:			dc.l	0
-ZDIFF2:			dc.l	0
+XDiff_w:			dc.w	0
+ZDiff_w:			dc.w	0
 
 				even
 
 				ds.w	4
 
-liftanimtab:
+;liftanimtab:
 
-endliftanimtab:
+;endliftanimtab:
 
-glassball:
+;glassball:
 ; incbin "glassball.inc"
 
-endglass
-glassballpt:	dc.l	glassball
+;endglass
+;glassballpt:	dc.l	glassball
 
-rndtab:			;		incbin					"randfile"
-endrnd:
+;rndtab:			;		incbin					"randfile"
+;endrnd:
 
 brightanimtab:
 ; dcb.w 200,20

--- a/ab3d2_source/hires.s
+++ b/ab3d2_source/hires.s
@@ -975,9 +975,6 @@ clrmessbuff:
 				move.l	#0,PLR2s_xspdval
 				move.l	#0,PLR2s_zspdval
 				move.l	#0,PLR2s_yvel
-				move.l	#0,Plr1_XSpdVal_l
-				move.l	#0,Plr1_ZSpdVal_l
-				move.l	#0,Plr1_YVel_l
 				move.l	#0,PLR2_xspdval
 				move.l	#0,PLR2_zspdval
 				move.l	#0,PLR2_yvel
@@ -3846,10 +3843,8 @@ PLR1_Control:
 ; Take a snapshot of everything.
 
 				move.l	Plr1_XOff_l,d2
-				move.l	d2,Plr1_OldXOff_l
 				move.l	d2,oldx
 				move.l	Plr1_ZOff_l,d3
-				move.l	d3,Plr1_OldYOff_l
 				move.l	d3,oldz
 				move.l	p1_xoff,d0
 				move.l	d0,Plr1_XOff_l
@@ -12003,37 +11998,36 @@ Zone:			dc.w	0
 
 ; Player data definiton - TODO remove unused, tighten definitions, fix alignments
 PLR1:			dc.b	$ff
-				even
-Plr1_Energy_w:	dc.w	191
-Plr1_GunSelected_w: dc.w	0
-Plr1_CosVal_w:	dc.w	0
-Plr1_SinVal_w:	dc.w	0
-Plr1_AngPos_w:	dc.w	0
-Plr1_AngSpd_w:	dc.w	0 ; unused
-Plr1_XOff_l:		dc.l	0 ; sometimes accessed as w - todo understand real size
-Plr1_YOff_l:		dc.l	0
-Plr1_YVel_l:		dc.l	0 ; write once, never read
-Plr1_ZOff_l:		dc.l	0
-Plr1_TYOff_l:		dc.l	0 ; unused
-Plr1_XSpdVal_l:	dc.l	0 ; write once, never read
-Plr1_ZSpdVal_l:	dc.l	0 ; write once, never read
-Plr1_Zone_w:		dc.w	0
-Plr1_RoomPtr_l:	dc.l	0
-Plr1_FloorSpd_l:	dc.l	0
-Plr2_FloorSpd_l:	dc.l	0
-Plr1_OldRoomPtr_l:	dc.l	0
-Plr1_PointsToRotatePtr_l: dc.l 0
-Plr1_ListOfGraphRoomsPtr_l: dc.l 0
-Plr1_OldXOff_l:	dc.l	0 ; write once, never read
-Plr1_OldYOff_l:	dc.l	0 ; write once, never read
-Plr1_StoodInTop_b: dc.b	0
-				even
-Plr1_Height_l:	dc.l	0
-Plr1_RoomBright_w: dc.w	0
+				CNOP 0, 4
+; long aligned fields first
+Plr1_XOff_l:				dc.l	0 ; sometimes accessed as w - todo understand real size
+Plr1_YOff_l:				dc.l	0
+Plr1_ZOff_l:				dc.l	0 ; sometimes accessed as w - todo understand real size
+Plr1_RoomPtr_l:				dc.l	0
+Plr1_OldRoomPtr_l:			dc.l	0
+Plr1_PointsToRotatePtr_l:	dc.l	0
+Plr1_ListOfGraphRoomsPtr_l:	dc.l	0
+Plr1_Height_l:				dc.l	0
 
+; word aligned fields next
+Plr1_Energy_w:				dc.w	191
+Plr1_GunSelected_w: 		dc.w	0
+Plr1_CosVal_w:				dc.w	0
+Plr1_SinVal_w:				dc.w	0
+Plr1_AngPos_w:				dc.w	0
+Plr1_Zone_w:				dc.w	0
+Plr1_FloorSpd_w:			dc.w	0
+Plr1_RoomBright_w: 			dc.w	0
+
+; byte aligned fields next
+Plr1_StoodInTop_b: 			dc.b	0
+Plr1_Teleported_b:			dc.b	0 ; delcared as word, accessed as byte
+Plr1_Echo_b:				dc.b	0 ; declared as word, accessed as byte
+
+				even
 DOUBLEWIDTH:	dc.b	$0,0
 DOUBLEHEIGHT:	dc.b	0,0
-Plr1_Teleported_b: dc.w	0 ; delcared as word, accessed as byte
+
 Plr2_Teleported_b: dc.w	0 ; delcared as word, accessed as byte
 
 				ds.w	4
@@ -12048,6 +12042,7 @@ ZDIFF1:			dc.l	0
 XDIFF2:			dc.l	0
 ZDIFF2:			dc.l	0
 
+; Snapshot
 Plr1_AltCosVal_w:	dc.w	0
 Plr1_AltSinVal_w:	dc.w	0
 Plr1_AltAngPos_w:	dc.w	0
@@ -12059,17 +12054,9 @@ Plr1_AltZOff_l:		dc.l	0
 Plr1_AltTYOff_l:	dc.l	0
 Plr1_AltXSpdVal_l:	dc.l	0
 Plr1_AltZSpdVal_l:	dc.l	0
-Plr1_AltZone_w:		dc.w	0 ; unused
-Plr1_AltRoomPtr_l:	dc.l	0 ; unused
-Plr1_AltOldRoomPtr_l: dc.l	0 ; unused
-Plr1_AltPointsToRotatePtr_l: dc.l 0 ; unused
-Plr1_AltListOfGraphRooms_l: dc.l 0 ; unused
-Plr1_AltOldXOff_l:	dc.l	0 ; unused
-Plr1_AltOldZOff_l:	dc.l	0 ; unused
 Plr1_AltHeight_l:	dc.l	0
 Plr1_AltTargHeight_l: dc.l	0
 
-Plr1_Echo_b:		dc.w	0 ; declared as word, accessed as byte
 
 p1_xoff:		dc.l	0
 p1_zoff:		dc.l	0
@@ -12114,6 +12101,8 @@ PLR2_StoodInTop: dc.b	0
 PLR2_height:	dc.l	0
 PLR2_Echo:		dc.w	0
 PlayEcho:		dc.w	0
+
+Plr2_FloorSpd_l:			dc.l	0
 
 				ds.w	4
 

--- a/ab3d2_source/leveldata2.s
+++ b/ab3d2_source/leveldata2.s
@@ -15,9 +15,9 @@ INITPLAYER:
 				move.l	Plr1_RoomPtr_l,a0
 				move.l	ZoneT_Floor_l(a0),d0
 				sub.l	#playerheight,d0
-				move.l	d0,Plr1_AltYOff_l
+				move.l	d0,Plr1_SnapYOff_l
 				move.l	d0,Plr1_YOff_l
-				move.l	d0,Plr1_AltTYOff_l
+				move.l	d0,Plr1_SnapTYOff_l
 				move.l	Plr1_RoomPtr_l,Plr1_OldRoomPtr_l
 
 				move.l	LEVELDATA,a1
@@ -26,26 +26,26 @@ INITPLAYER:
 				move.l	ZoneAdds,a0
 				move.l	(a0,d0.w*4),d0
 				add.l	LEVELDATA,d0
-				move.l	d0,PLR2_Roompt
-				move.l	PLR2_Roompt,a0
+				move.l	d0,Plr2_RoomPtr_l
+				move.l	Plr2_RoomPtr_l,a0
 				move.l	ZoneT_Floor_l(a0),d0
 				sub.l	#playerheight,d0
-				move.l	d0,PLR2s_yoff
-				move.l	d0,PLR2_yoff
-				move.l	d0,PLR2s_tyoff
-				move.l	d0,PLR2_yoff
+				move.l	d0,Plr2_SnapYOff_l
+				move.l	d0,Plr2_YOff_l
+				move.l	d0,Plr2_SnapTYOff_l
+				move.l	d0,Plr2_YOff_l
 
-				move.l	PLR2_Roompt,PLR2_OldRoompt
+				move.l	Plr2_RoomPtr_l,Plr2_OldRoomPtr_l
 
 
-				move.w	(a1),Plr1_AltXOff_l
-				move.w	2(a1),Plr1_AltZOff_l
+				move.w	(a1),Plr1_SnapXOff_l
+				move.w	2(a1),Plr1_SnapZOff_l
 				move.w	(a1),Plr1_XOff_l
 				move.w	2(a1),Plr1_ZOff_l
-				move.w	6(a1),PLR2s_xoff
-				move.w	8(a1),PLR2s_zoff
-				move.w	6(a1),PLR2_xoff
-				move.w	8(a1),PLR2_zoff
+				move.w	6(a1),Plr2_SnapXOff_l
+				move.w	8(a1),Plr2_SnapZOff_l
+				move.w	6(a1),Plr2_XOff_l
+				move.w	8(a1),Plr2_ZOff_l
 				rts
 
 *************************************************

--- a/ab3d2_source/leveldata2.s
+++ b/ab3d2_source/leveldata2.s
@@ -11,14 +11,14 @@ INITPLAYER:
 				move.l	ZoneAdds,a0
 				move.l	(a0,d0.w*4),d0
 				add.l	LEVELDATA,d0
-				move.l	d0,PLR1_Roompt
-				move.l	PLR1_Roompt,a0
+				move.l	d0,Plr1_RoomPtr_l
+				move.l	Plr1_RoomPtr_l,a0
 				move.l	ZoneT_Floor_l(a0),d0
 				sub.l	#playerheight,d0
-				move.l	d0,PLR1s_yoff
-				move.l	d0,PLR1_yoff
-				move.l	d0,PLR1s_tyoff
-				move.l	PLR1_Roompt,PLR1_OldRoompt
+				move.l	d0,Plr1_AltYOff_l
+				move.l	d0,Plr1_YOff_l
+				move.l	d0,Plr1_AltTYOff_l
+				move.l	Plr1_RoomPtr_l,Plr1_OldRoomPtr_l
 
 				move.l	LEVELDATA,a1
 				add.l	#160*10,a1
@@ -38,10 +38,10 @@ INITPLAYER:
 				move.l	PLR2_Roompt,PLR2_OldRoompt
 
 
-				move.w	(a1),PLR1s_xoff
-				move.w	2(a1),PLR1s_zoff
-				move.w	(a1),PLR1_xoff
-				move.w	2(a1),PLR1_zoff
+				move.w	(a1),Plr1_AltXOff_l
+				move.w	2(a1),Plr1_AltZOff_l
+				move.w	(a1),Plr1_XOff_l
+				move.w	2(a1),Plr1_ZOff_l
 				move.w	6(a1),PLR2s_xoff
 				move.w	8(a1),PLR2s_zoff
 				move.w	6(a1),PLR2_xoff

--- a/ab3d2_source/modules/ai.s
+++ b/ab3d2_source/modules/ai.s
@@ -738,8 +738,8 @@ ai_ChargeCommon:
 				move.w	Plr1_ZOff_l,newz
 				move.w	Plr1_SinVal_w,tempsin
 				move.w	Plr1_CosVal_w,tempcos
-				move.w	p1_xoff,tempx
-				move.w	p1_zoff,tempz
+				move.w	Plr1_TmpXOff_l,tempx
+				move.w	Plr1_TmpZOff_l,tempz
 				tst.b	ai_ToSide_w
 				beq.s	.no_side
 				jsr		RunAround
@@ -997,9 +997,9 @@ ai_AttackWithHitScan:
 				sub.l	#ObjRotated,a6
 				add.l	ObjectPoints,a6
 				move.w	(a6),d0
-				sub.w	p1_xoff,d0				;dx
+				sub.w	Plr1_TmpXOff_l,d0				;dx
 				move.w	4(a6),d1
-				sub.w	p1_zoff,d1				;dz
+				sub.w	Plr1_TmpZOff_l,d1				;dz
 
 				move.w	d0,d2
 				move.w	d1,d3
@@ -1187,8 +1187,8 @@ ai_ChargeFlyingCommon:
 				move.w	Plr1_ZOff_l,newz
 				move.w	Plr1_SinVal_w,tempsin
 				move.w	Plr1_CosVal_w,tempcos
-				move.w	p1_xoff,tempx
-				move.w	p1_zoff,tempz
+				move.w	Plr1_TmpXOff_l,tempx
+				move.w	Plr1_TmpZOff_l,tempz
 				tst.b	ai_ToSide_w
 				beq.s	.no_side
 				jsr		RunAround
@@ -1405,8 +1405,8 @@ ai_ApproachCommon:
 				move.w	Plr1_ZOff_l,newz
 				move.w	Plr1_SinVal_w,tempsin
 				move.w	Plr1_CosVal_w,tempcos
-				move.w	p1_xoff,tempx
-				move.w	p1_zoff,tempz
+				move.w	Plr1_TmpXOff_l,tempx
+				move.w	Plr1_TmpZOff_l,tempz
 				tst.b	ai_ToSide_w
 				beq.s	.no_side
 				jsr		RunAround
@@ -1725,9 +1725,9 @@ ai_CheckInFront:
 				move.w	(a1,d0.w*8),newx
 				move.w	4(a1,d0.w*8),newz
 
-				move.w	p1_xoff,d0
+				move.w	Plr1_TmpXOff_l,d0
 				sub.w	newx,d0
-				move.w	p1_zoff,d1
+				move.w	Plr1_TmpZOff_l,d1
 				sub.w	newz,d1
 
 				move.w	EntT_CurrentAngle_w(a0),d2

--- a/ab3d2_source/modules/ai.s
+++ b/ab3d2_source/modules/ai.s
@@ -69,8 +69,8 @@ ai_DoTakeDamage:
 
 .no_copy_in:
 				movem.l	d0-d7/a0-a6,-(a7)
-				move.w	PLR1_xoff,newx
-				move.w	PLR1_zoff,newz
+				move.w	Plr1_XOff_l,newx
+				move.w	Plr1_ZOff_l,newz
 				move.w	(a0),d1
 				move.l	ObjectPoints,a1
 				lea		(a1,d1.w*8),a1
@@ -142,8 +142,8 @@ ai_TakeDamage:
 				move.l	ObjectPoints,a1
 				move.w	(a1,d0.w*8),oldx
 				move.w	4(a1,d0.w*8),oldz
-				move.w	PLR1_xoff,newx
-				move.w	PLR1_zoff,newz
+				move.w	Plr1_XOff_l,newx
+				move.w	Plr1_ZOff_l,newz
 				move.w	#100,speed
 				move.w	#-20,Range
 				jsr		HeadTowardsAng
@@ -418,8 +418,8 @@ ai_Widget:
 				tst.w	AI_Player1NoiseVol_w
 				beq.s	.no_player_noise
 
-				move.l	PLR1_Roompt,a1
-				tst.b	PLR1_StoodInTop
+				move.l	Plr1_RoomPtr_l,a1
+				tst.b	Plr1_StoodInTop_b
 				beq.s	.player_not_in_top
 
 				addq	#1,a1
@@ -734,10 +734,10 @@ ai_ChargeCommon:
 				bra		.no_munch
 
 .no_teleport:
-				move.w	PLR1_xoff,newx
-				move.w	PLR1_zoff,newz
-				move.w	PLR1_sinval,tempsin
-				move.w	PLR1_cosval,tempcos
+				move.w	Plr1_XOff_l,newx
+				move.w	Plr1_ZOff_l,newz
+				move.w	Plr1_SinVal_w,tempsin
+				move.w	Plr1_CosVal_w,tempcos
 				move.w	p1_xoff,tempx
 				move.w	p1_zoff,tempz
 				tst.b	ai_ToSide_w
@@ -909,8 +909,8 @@ ai_AttackWithHitScan:
 				jsr		ai_DoAttackAnim
 
 				movem.l	d0-d7/a0-a6,-(a7)
-				move.w	PLR1_xoff,newx
-				move.w	PLR1_zoff,newz
+				move.w	Plr1_XOff_l,newx
+				move.w	Plr1_ZOff_l,newz
 				move.w	(a0),d1
 				move.l	ObjectPoints,a1
 				lea		(a1,d1.w*8),a1
@@ -1062,8 +1062,8 @@ ai_AttackWithProjectile:
 				jsr		ai_DoAttackAnim
 
 				movem.l	d0-d7/a0-a6,-(a7)
-				move.w	PLR1_xoff,newx
-				move.w	PLR1_zoff,newz
+				move.w	Plr1_XOff_l,newx
+				move.w	Plr1_ZOff_l,newz
 				move.w	(a0),d1
 				move.l	ObjectPoints,a1
 				lea		(a1,d1.w*8),a1
@@ -1183,10 +1183,10 @@ ai_ChargeFlyingCommon:
 				lea		(a6,d1.w*8),a6
 				move.w	(a1),oldx
 				move.w	4(a1),oldz
-				move.w	PLR1_xoff,newx
-				move.w	PLR1_zoff,newz
-				move.w	PLR1_sinval,tempsin
-				move.w	PLR1_cosval,tempcos
+				move.w	Plr1_XOff_l,newx
+				move.w	Plr1_ZOff_l,newz
+				move.w	Plr1_SinVal_w,tempsin
+				move.w	Plr1_CosVal_w,tempcos
 				move.w	p1_xoff,tempx
 				move.w	p1_zoff,tempz
 				tst.b	ai_ToSide_w
@@ -1401,10 +1401,10 @@ ai_ApproachCommon:
 				move.w	(a1),oldx
 				move.w	4(a1),oldz
 
-				move.w	PLR1_xoff,newx
-				move.w	PLR1_zoff,newz
-				move.w	PLR1_sinval,tempsin
-				move.w	PLR1_cosval,tempcos
+				move.w	Plr1_XOff_l,newx
+				move.w	Plr1_ZOff_l,newz
+				move.w	Plr1_SinVal_w,tempsin
+				move.w	Plr1_CosVal_w,tempcos
 				move.w	p1_xoff,tempx
 				move.w	p1_zoff,tempz
 				tst.b	ai_ToSide_w
@@ -1553,7 +1553,7 @@ ai_FlyToCPTHeight:
 				bra		ai_FlyToHeightCommon
 
 ai_FlyToPlayerHeight:
-				move.l	PLR1_yoff,d1
+				move.l	Plr1_YOff_l,d1
 				asr.l	#7,d1
 
 ai_FlyToHeightCommon:
@@ -1627,13 +1627,13 @@ ai_StorePlayerPosition:
 				move.l	#ai_NastyWork_vl,a2
 				asl.w	#4,d0
 				add.w	d0,a2
-				move.w	PLR1_xoff,AI_WorkT_LastX_w(a2)
-				move.w	PLR1_zoff,AI_WorkT_LastY_w(a2)
-				move.l	PLR1_Roompt,a3
+				move.w	Plr1_XOff_l,AI_WorkT_LastX_w(a2)
+				move.w	Plr1_ZOff_l,AI_WorkT_LastY_w(a2)
+				move.l	Plr1_RoomPtr_l,a3
 				move.w	(a3),AI_WorkT_LastZone_w(a2)
 				moveq	#0,d0
 				move.b	ZoneT_ControlPoint_w(a3),d0
-				tst.b	PLR1_StoodInTop
+				tst.b	Plr1_StoodInTop_b
 				beq.s	.player_not_in_top
 				move.b	ZoneT_ControlPoint_w+1(a3),d0
 
@@ -1644,13 +1644,13 @@ ai_StorePlayerPosition:
 				move.l	#AI_Teamwork_vl,a2
 				asl.w	#4,d0
 				add.w	d0,a2
-				move.w	PLR1_xoff,AI_WorkT_LastX_w(a2)
-				move.w	PLR1_zoff,AI_WorkT_LastY_w(a2)
-				move.l	PLR1_Roompt,a3
+				move.w	Plr1_XOff_l,AI_WorkT_LastX_w(a2)
+				move.w	Plr1_ZOff_l,AI_WorkT_LastY_w(a2)
+				move.l	Plr1_RoomPtr_l,a3
 				move.w	(a3),AI_WorkT_LastZone_w(a2)
 				moveq	#0,d0
 				move.b	ZoneT_ControlPoint_w(a3),d0
-				tst.b	PLR1_StoodInTop
+				tst.b	Plr1_StoodInTop_b
 				beq.s	.player_not_in_top2
 				move.b	ZoneT_ControlPoint_w+1(a3),d0
 
@@ -1697,14 +1697,14 @@ ai_GetRoomStatsStill:
 
 ai_CheckForDark:
 				move.w	(a0),d0
-				move.l	PLR1_Roompt,a3
+				move.l	Plr1_RoomPtr_l,a3
 				move.w	(a3),d1
 				cmp.w	d1,d0
 				beq.s	.not_in_dark
 
 				jsr		GetRand
 				and.w	#31,d0
-				cmp.w	PLR1_RoomBright,d0
+				cmp.w	Plr1_RoomBright_w,d0
 				bge.s	.not_in_dark
 
 .in_dark:
@@ -1747,14 +1747,14 @@ AI_LookForPlayer1:
 				clr.b	17(a0)
 				clr.b	CanSee
 				move.b	ShotT_InUpperZone_b(a0),ViewerTop
-				move.b	PLR1_StoodInTop,TargetTop
-				move.l	PLR1_Roompt,ToRoom
+				move.b	Plr1_StoodInTop_b,TargetTop
+				move.l	Plr1_RoomPtr_l,ToRoom
 				move.l	objroom,FromRoom
 				move.w	newx,Viewerx
 				move.w	newz,Viewerz
-				move.w	PLR1_xoff,Targetx
-				move.w	PLR1_zoff,Targetz
-				move.l	PLR1_yoff,d0
+				move.w	Plr1_XOff_l,Targetx
+				move.w	Plr1_ZOff_l,Targetz
+				move.l	Plr1_YOff_l,d0
 				asr.l	#7,d0
 				move.w	d0,Targety
 				move.w	4(a0),Viewery
@@ -2209,10 +2209,10 @@ BLIBBLE:
 
 ai_CheckAttackOnGround:
 
-				move.l	PLR1_Roompt,a3
+				move.l	Plr1_RoomPtr_l,a3
 				moveq	#0,d1
 				move.b	ZoneT_ControlPoint_w(a3),d1
-				tst.b	PLR1_StoodInTop
+				tst.b	Plr1_StoodInTop_b
 				beq.s	.player_not_in_top
 				move.b	ZoneT_ControlPoint_w+1(a3),d1
 

--- a/ab3d2_source/newaliencontrol.s
+++ b/ab3d2_source/newaliencontrol.s
@@ -761,20 +761,20 @@ CHECKPLAYERGOT:
 CHECKNEARBYONE:
 
 				move.l	StatPointer,a2
-				move.b	PLR1_StoodInTop,d0
+				move.b	Plr1_StoodInTop_b,d0
 				move.b	ShotT_InUpperZone_b(a0),d1
 				eor.b	d0,d1
 				bne		.NotSameZone
 
-				move.w	PLR1_xoff,oldx
-				move.w	PLR1_zoff,oldz
-				move.w	PLR1_Zone,d7
+				move.w	Plr1_XOff_l,oldx
+				move.w	Plr1_ZOff_l,oldz
+				move.w	Plr1_Zone_w,d7
 
 				cmp.w	12(a0),d7
 				bne		.NotSameZone
 
-				move.l	PLR1_yoff,d7
-				move.l	PLR1_height,d6
+				move.l	Plr1_YOff_l,d7
+				move.l	Plr1_Height_l,d6
 				asr.l	#1,d6
 				add.l	d6,d7
 				asr.l	#7,d7
@@ -1296,8 +1296,8 @@ FireAtPlayer1:
 				lea		(a2,d1.w*8),a2
 				move.w	(a1),oldx
 				move.w	4(a1),oldz
-				move.w	PLR1_xoff,newx
-				move.w	PLR1_zoff,newz
+				move.w	Plr1_XOff_l,newx
+				move.w	Plr1_ZOff_l,newz
 
 				jsr		CalcDist
 				move.w	XDIFF1,d6

--- a/ab3d2_source/newaliencontrol.s
+++ b/ab3d2_source/newaliencontrol.s
@@ -1300,12 +1300,12 @@ FireAtPlayer1:
 				move.w	Plr1_ZOff_l,newz
 
 				jsr		CalcDist
-				move.w	XDIFF1,d6
+				move.w	XDiff_w,d6
 				muls	distaway,d6
 				divs	SHOTSPEED,d6
 				asr.w	#4,d6
 				add.w	d6,newx
-				move.w	ZDIFF1,d6
+				move.w	ZDiff_w,d6
 				muls	distaway,d6
 				divs	SHOTSPEED,d6
 				asr.w	#4,d6

--- a/ab3d2_source/newaliencontrol.s
+++ b/ab3d2_source/newaliencontrol.s
@@ -268,7 +268,7 @@ Activatable:
 				tst.b	d0
 				beq.s	.NotActivated1
 
-				tst.b	p1_spctap
+				tst.b	Plr1_TmpSpcTap_b
 				beq.s	.NotActivated1
 
 ; The player has pressed the spacebar
@@ -291,7 +291,7 @@ Activatable:
 				tst.b	d0
 				beq.s	.NotActivated2
 
-				tst.b	p2_spctap
+				tst.b	Plr2_TmpSpcTap_b
 				beq.s	.NotActivated2
 
 ; The player has pressed the spacebar
@@ -362,7 +362,7 @@ ACTIVATED:
 				tst.b	d0
 				beq.s	.NotDeactivated1
 
-				tst.b	p1_spctap
+				tst.b	Plr1_TmpSpcTap_b
 				beq.s	.NotDeactivated1
 
 ; The player has pressed the spacebar
@@ -383,7 +383,7 @@ ACTIVATED:
 				tst.b	d0
 				beq.s	.NotDeactivated2
 
-				tst.b	p2_spctap
+				tst.b	Plr2_TmpSpcTap_b
 				beq.s	.NotDeactivated2
 
 ; The player has pressed the spacebar
@@ -802,20 +802,20 @@ CHECKNEARBYONE:
 CHECKNEARBYTWO:
 
 				move.l	StatPointer,a2
-				move.b	PLR2_StoodInTop,d0
+				move.b	Plr2_StoodInTop_b,d0
 				move.b	ShotT_InUpperZone_b(a0),d1
 				eor.b	d0,d1
 				bne		.NotSameZone
 
-				move.w	PLR2_xoff,oldx
-				move.w	PLR2_zoff,oldz
-				move.w	PLR2_Zone,d7
+				move.w	Plr2_XOff_l,oldx
+				move.w	Plr2_ZOff_l,oldz
+				move.w	Plr2_Zone_w,d7
 
 				cmp.w	12(a0),d7
 				bne		.NotSameZone
 
-				move.l	PLR2_yoff,d7
-				move.l	PLR2_height,d6
+				move.l	Plr2_YOff_l,d7
+				move.l	Plr2_Height_l,d6
 				asr.l	#1,d6
 				add.l	d6,d7
 				asr.l	#7,d7
@@ -1138,8 +1138,8 @@ SHOOTPLAYER1
 				move.w	newx,fsx
 				move.w	newz,fsz
 
-				move.w	p1_xoff,newx
-				move.w	p1_zoff,newz
+				move.w	Plr1_TmpXOff_l,newx
+				move.w	Plr1_TmpZOff_l,newz
 				move.w	(a1),oldx
 				move.w	4(a1),oldz
 
@@ -1156,7 +1156,7 @@ SHOOTPLAYER1
 				add.w	d1,newz
 				sub.w	d2,newx
 
-				move.l	p1_yoff,d1
+				move.l	Plr1_TmpYOff_l,d1
 				add.l	#15*128,d1
 				asr.l	#7,d1
 				move.w	d1,d2
@@ -1401,8 +1401,8 @@ SHOOTPLAYER2
 				move.w	newx,fsx
 				move.w	oldx,fsz
 
-				move.w	p2_xoff,newx
-				move.w	p2_zoff,newz
+				move.w	Plr2_TmpXOff_l,newx
+				move.w	Plr2_TmpZOff_l,newz
 				move.w	(a1),oldx
 				move.w	4(a1),oldz
 
@@ -1419,7 +1419,7 @@ SHOOTPLAYER2
 				add.w	d1,newz
 				sub.w	d2,newx
 
-				move.l	p2_yoff,d1
+				move.l	Plr2_TmpYOff_l,d1
 				add.l	#15*128,d1
 				asr.l	#7,d1
 				move.w	d1,d2
@@ -1549,8 +1549,8 @@ FireAtPlayer2:
 				lea		(a2,d1.w*8),a2
 				move.w	(a1),oldx
 				move.w	4(a1),oldz
-				move.w	PLR2_xoff,newx
-				move.w	PLR2_zoff,newz
+				move.w	Plr2_XOff_l,newx
+				move.w	Plr2_ZOff_l,newz
 				move.w	SHOTSPEED,speed
 				move.w	#0,Range
 				jsr		HeadTowards
@@ -1568,8 +1568,8 @@ FireAtPlayer2:
 				asr.l	#8,d1
 				add.w	d1,oldx
 				sub.w	d0,oldz
-				move.w	PLR2_xoff,newx
-				move.w	PLR2_zoff,newz
+				move.w	Plr2_XOff_l,newx
+				move.w	Plr2_ZOff_l,newz
 				jsr		HeadTowards
 
 .nooffset:

--- a/ab3d2_source/newanims.s
+++ b/ab3d2_source/newanims.s
@@ -812,7 +812,7 @@ objmoveanim:
 				bsr		DoorRoutine
 
 
-				move.w	#0,Plr1_FloorSpd_l
+				move.w	#0,Plr1_FloorSpd_w
 				move.w	#0,Plr2_FloorSpd_l
 
 				bsr		LiftRoutine
@@ -1052,7 +1052,7 @@ notallliftsdone:
 				seq		PLR1_stoodonlift
 				bne.s	.nosetfloorspd1
 
-				move.w	FLOORMOVESPD,Plr1_FloorSpd_l
+				move.w	FLOORMOVESPD,Plr1_FloorSpd_w
 
 .nosetfloorspd1:
 

--- a/ab3d2_source/newanims.s
+++ b/ab3d2_source/newanims.s
@@ -790,12 +790,12 @@ objmoveanim:
 
 				move.l	Plr1_RoomPtr_l,a0
 				move.w	(a0),Plr1_Zone_w
-				move.l	PLR2_Roompt,a0
-				move.w	(a0),PLR2_Zone
+				move.l	Plr2_RoomPtr_l,a0
+				move.w	(a0),Plr2_Zone_w
 
 				cmp.b	#'n',mors
 				bne.s	.okp2
-				move.w	#-5,PLR2_Zone
+				move.w	#-5,Plr2_Zone_w
 .okp2:
 
 				move.w	#0,AI_Player1NoiseVol_w
@@ -813,7 +813,7 @@ objmoveanim:
 
 
 				move.w	#0,Plr1_FloorSpd_w
-				move.w	#0,Plr2_FloorSpd_l
+				move.w	#0,Plr2_FloorSpd_w
 
 				bsr		LiftRoutine
 				cmp	#0,animtimer		;animtimer decriment moved to VBlankInterrupt:
@@ -939,8 +939,8 @@ notallliftsdone:
 				subq.w	#1,CLOSEDSFX
 				move.w	(a0)+,d2
 				move.w	(a0)+,d3
-				sub.w	p1_xoff,d2
-				sub.w	p1_zoff,d3
+				sub.w	Plr1_TmpXOff_l,d2
+				sub.w	Plr1_TmpZOff_l,d3
 				move.w	cosval,d4
 				move.w	sinval,d5
 
@@ -1056,12 +1056,12 @@ notallliftsdone:
 
 .nosetfloorspd1:
 
-				move.l	PLR2_Roompt,a3
+				move.l	Plr2_RoomPtr_l,a3
 				cmp.w	(a3),d5
 				seq		PLR2_stoodonlift
 				bne.s	.nosetfloorspd2
 
-				move.w	FLOORMOVESPD,Plr2_FloorSpd_l
+				move.w	FLOORMOVESPD,Plr2_FloorSpd_w
 
 .nosetfloorspd2:
 
@@ -1155,7 +1155,7 @@ tstliftlower:
 lift0:
 
 				moveq	#0,d1
-				tst.b	p1_spctap
+				tst.b	Plr1_TmpSpcTap_b
 				beq.s	.noplr1
 				move.w	#%100000000,d1
 				move.w	CLOSINGSPEED,d7
@@ -1165,7 +1165,7 @@ lift0:
 				bra		backfromlift
 
 .noplr1:
-				tst.b	p2_spctap
+				tst.b	Plr2_TmpSpcTap_b
 				beq.s	.noplr2
 				or.w	#%100000000000,d1
 				move.w	CLOSINGSPEED,d7
@@ -1210,7 +1210,7 @@ tstliftraise:
 rlift0:
 
 				moveq	#0,d1
-				tst.b	p1_spctap
+				tst.b	Plr1_TmpSpcTap_b
 				beq.s	.noplr1
 				move.w	#%100000000,d1
 				move.w	OPENINGSPEED,d7
@@ -1220,7 +1220,7 @@ rlift0:
 				bra		backfromlift
 
 .noplr1:
-				tst.b	p2_spctap
+				tst.b	Plr2_TmpSpcTap_b
 				beq.s	.noplr2
 				or.w	#%100000000000,d1
 				move.w	OPENINGSPEED,d7
@@ -1304,8 +1304,8 @@ notalldoorsdone:
 				subq.w	#1,CLOSEDSFX
 				move.w	(a0)+,d2
 				move.w	(a0)+,d3
-				sub.w	p1_xoff,d2
-				sub.w	p1_zoff,d3
+				sub.w	Plr1_TmpXOff_l,d2
+				sub.w	Plr1_TmpZOff_l,d3
 				move.w	cosval,d4
 				move.w	sinval,d5
 
@@ -1413,7 +1413,7 @@ NOTMOVING:
 				and.w	#255,d0
 ; add.w #64,d0
 
-				cmp.w	PLR2_Zone,d5
+				cmp.w	Plr2_Zone_w,d5
 				beq.s	.gobackup
 				cmp.w	Plr1_Zone_w,d5
 				bne.s	NotGoBackUp
@@ -1524,11 +1524,11 @@ tstdoortoopen:
 door0:
 
 				move.w	#$0,d1
-				tst.b	p1_spctap
+				tst.b	Plr1_TmpSpcTap_b
 				beq.s	.noplr1
 				move.w	#%100000000,d1
 .noplr1:
-				tst.b	p2_spctap
+				tst.b	Plr2_TmpSpcTap_b
 				beq.s	.noplr2
 				or.w	#%100000000000,d1
 .noplr2:
@@ -1590,10 +1590,10 @@ SwitchRoutine:
 				move.l	Points,a1
 CheckSwitches
 
-				tst.b	p1_spctap
+				tst.b	Plr1_TmpSpcTap_b
 				bne		p1_SpaceIsPressed
 backtop2
-				tst.b	p2_spctap
+				tst.b	Plr2_TmpSpcTap_b
 				bne		p2_SpaceIsPressed
 backtoend
 
@@ -1640,8 +1640,8 @@ nobutt:
 				rts
 
 p1_SpaceIsPressed:
-				move.w	p1_xoff,d1
-				move.w	p1_zoff,d2
+				move.w	Plr1_TmpXOff_l,d1
+				move.w	Plr1_TmpZOff_l,d2
 				move.w	(a0),d3
 				blt		.NotCloseEnough
 				move.w	4(a0),d3
@@ -1691,8 +1691,8 @@ p1_SpaceIsPressed:
 				bra		backtop2
 
 p2_SpaceIsPressed:
-				move.w	p2_xoff,d1
-				move.w	p2_zoff,d2
+				move.w	Plr2_TmpXOff_l,d1
+				move.w	Plr2_TmpZOff_l,d2
 				move.w	(a0),d3
 				blt		.NotCloseEnough
 				move.w	4(a0),d3
@@ -2049,11 +2049,11 @@ nodamage:
 
 .noseeplr1:
 
-				move.b	PLR2_StoodInTop,TargetTop
-				move.l	PLR2_Roompt,ToRoom
-				move.w	PLR2_xoff,Targetx
-				move.w	PLR2_zoff,Targetz
-				move.l	PLR2_yoff,d0
+				move.b	Plr2_StoodInTop_b,TargetTop
+				move.l	Plr2_RoomPtr_l,ToRoom
+				move.w	Plr2_XOff_l,Targetx
+				move.w	Plr2_ZOff_l,Targetz
+				move.l	Plr2_YOff_l,d0
 				asr.l	#7,d0
 				move.w	d0,Targety
 				move.w	4(a0),Viewery
@@ -2149,17 +2149,17 @@ HealFactor		EQU		18
 
 MEDIPLR2
 
-				cmp.w	#127,PLR2_energy
+				cmp.w	#127,Plr2_Energy_w
 				bge		.NotSameZone
 
-				move.b	PLR2_StoodInTop,d0
+				move.b	Plr2_StoodInTop_b,d0
 				move.b	ShotT_InUpperZone_b(a0),d1
 				eor.b	d1,d0
 				bne		.NotSameZone
 
-				move.w	PLR2_xoff,oldx
-				move.w	PLR2_zoff,oldz
-				move.w	PLR2_Zone,d7
+				move.w	Plr2_XOff_l,oldx
+				move.w	Plr2_ZOff_l,oldz
+				move.w	Plr2_Zone_w,d7
 				move.w	12(a0),d0
 
 				cmp.w	12(a0),d7
@@ -2189,12 +2189,12 @@ MEDIPLR2
 				move.w	#-1,12(a0)
 				move.w	#-1,EntT_GraphicRoom_w(a0)
 				move.w	HealFactor(a0),d0
-				add.w	PLR2_energy,d0
+				add.w	Plr2_Energy_w,d0
 				cmp.w	#127,d0
 				ble.s	.okokokokokok
 				move.w	#127,d0
 .okokokokokok:
-				move.w	d0,PLR2_energy
+				move.w	d0,Plr2_Energy_w
 
 .NotPickedUp:
 

--- a/ab3d2_source/newanims.s
+++ b/ab3d2_source/newanims.s
@@ -788,8 +788,8 @@ BACKSFX:
 
 objmoveanim:
 
-				move.l	PLR1_Roompt,a0
-				move.w	(a0),PLR1_Zone
+				move.l	Plr1_RoomPtr_l,a0
+				move.w	(a0),Plr1_Zone_w
 				move.l	PLR2_Roompt,a0
 				move.w	(a0),PLR2_Zone
 
@@ -812,8 +812,8 @@ objmoveanim:
 				bsr		DoorRoutine
 
 
-				move.w	#0,PLR1_FloorSpd
-				move.w	#0,PLR2_FloorSpd
+				move.w	#0,Plr1_FloorSpd_l
+				move.w	#0,Plr2_FloorSpd_l
 
 				bsr		LiftRoutine
 				cmp	#0,animtimer		;animtimer decriment moved to VBlankInterrupt:
@@ -1044,7 +1044,7 @@ notallliftsdone:
 				move.l	(a1,d5.w*4),a1
 				add.l	LEVELDATA,a1
 				move.w	(a1),d5
-				move.l	PLR1_Roompt,a3
+				move.l	Plr1_RoomPtr_l,a3
 				move.l	d3,2(a1)
 				neg.w	d0
 
@@ -1052,7 +1052,7 @@ notallliftsdone:
 				seq		PLR1_stoodonlift
 				bne.s	.nosetfloorspd1
 
-				move.w	FLOORMOVESPD,PLR1_FloorSpd
+				move.w	FLOORMOVESPD,Plr1_FloorSpd_l
 
 .nosetfloorspd1:
 
@@ -1061,7 +1061,7 @@ notallliftsdone:
 				seq		PLR2_stoodonlift
 				bne.s	.nosetfloorspd2
 
-				move.w	FLOORMOVESPD,PLR2_FloorSpd
+				move.w	FLOORMOVESPD,Plr2_FloorSpd_l
 
 .nosetfloorspd2:
 
@@ -1415,7 +1415,7 @@ NOTMOVING:
 
 				cmp.w	PLR2_Zone,d5
 				beq.s	.gobackup
-				cmp.w	PLR1_Zone,d5
+				cmp.w	Plr1_Zone_w,d5
 				bne.s	NotGoBackUp
 .gobackup:
 				tst.b	dooropen
@@ -2025,8 +2025,8 @@ nodamage:
 				move.w	(a1,d0.w*8),Viewerx
 				move.w	4(a1,d0.w*8),Viewerz
 				move.b	ShotT_InUpperZone_b(a0),ViewerTop
-				move.b	PLR1_StoodInTop,TargetTop
-				move.l	PLR1_Roompt,ToRoom
+				move.b	Plr1_StoodInTop_b,TargetTop
+				move.l	Plr1_RoomPtr_l,ToRoom
 
 				move.w	12(a0),d0
 				move.l	ZoneAdds,a1
@@ -2034,9 +2034,9 @@ nodamage:
 				add.l	LEVELDATA,a1
 				move.l	a1,FromRoom
 
-				move.w	PLR1_xoff,Targetx
-				move.w	PLR1_zoff,Targetz
-				move.l	PLR1_yoff,d0
+				move.w	Plr1_XOff_l,Targetx
+				move.w	Plr1_ZOff_l,Targetz
+				move.l	Plr1_YOff_l,d0
 				asr.l	#7,d0
 				move.w	d0,Targety
 				move.w	4(a0),Viewery
@@ -2097,17 +2097,17 @@ ItsAMediKit:
 HealFactor		EQU		18
 
 
-				cmp.w	#127,PLR1_energy
+				cmp.w	#127,Plr1_Energy_w
 				bge		.NotSameZone
 
-				move.b	PLR1_StoodInTop,d0
+				move.b	Plr1_StoodInTop_b,d0
 				move.b	ShotT_InUpperZone_b(a0),d1
 				eor.b	d1,d0
 				bne		.NotSameZone
 
-				move.w	PLR1_xoff,oldx
-				move.w	PLR1_zoff,oldz
-				move.w	PLR1_Zone,d7
+				move.w	Plr1_XOff_l,oldx
+				move.w	Plr1_ZOff_l,oldz
+				move.w	Plr1_Zone_w,d7
 
 				cmp.w	12(a0),d7
 				bne		.NotSameZone
@@ -2136,12 +2136,12 @@ HealFactor		EQU		18
 				move.w	#-1,12(a0)
 				move.w	#-1,EntT_GraphicRoom_w(a0)
 				move.w	HealFactor(a0),d0
-				add.w	PLR1_energy,d0
+				add.w	Plr1_Energy_w,d0
 				cmp.w	#127,d0
 				ble.s	.okokokokokok
 				move.w	#127,d0
 .okokokokokok:
-				move.w	d0,PLR1_energy
+				move.w	d0,Plr1_Energy_w
 
 .NotPickedUp:
 
@@ -2233,14 +2233,14 @@ ItsAKey:
 				move.w	12(a0),EntT_GraphicRoom_w(a0)
 				clr.b	ShotT_Worry_b(a0)
 
-				move.b	PLR1_StoodInTop,d0
+				move.b	Plr1_StoodInTop_b,d0
 				move.b	ShotT_InUpperZone_b(a0),d1
 				eor.b	d1,d0
 				bne		.NotSameZone
 
-				move.w	PLR1_xoff,oldx
-				move.w	PLR1_zoff,oldz
-				move.w	PLR1_Zone,d7
+				move.w	Plr1_XOff_l,oldx
+				move.w	Plr1_ZOff_l,oldz
+				move.w	Plr1_Zone_w,d7
 				move.w	12(a0),d0
 				move.l	ZoneAdds,a1
 				move.l	(a1,d0.w*4),a1

--- a/ab3d2_source/newplayershoot.s
+++ b/ab3d2_source/newplayershoot.s
@@ -58,18 +58,18 @@ okcanfire:
 ;
 ;.itsahold:
 
-				move.w	PLR1_angpos,d0
+				move.w	Plr1_AngPos_w,d0
 				move.w	d0,tempangpos
 				move.l	#SineTable,a0
 				lea		(a0,d0.w),a0
 				move.w	(a0),tempxdir
 				move.w	2048(a0),tempzdir
-				move.w	PLR1_xoff,tempxoff
-				move.w	PLR1_zoff,tempzoff
-				move.l	PLR1_yoff,tempyoff
+				move.w	Plr1_XOff_l,tempxoff
+				move.w	Plr1_ZOff_l,tempzoff
+				move.l	Plr1_YOff_l,tempyoff
 				add.l	#10*128,tempyoff
-				move.b	PLR1_StoodInTop,tempStoodInTop
-				move.l	PLR1_Roompt,tempRoompt
+				move.b	Plr1_StoodInTop_b,tempStoodInTop
+				move.l	Plr1_RoomPtr_l,tempRoompt
 				move.l	#%100011,d7
 				move.w	#-1,d0
 				move.l	#0,targetydiff
@@ -105,7 +105,7 @@ findclosestinline
 				move.w	4(a0),d2
 				ext.l	d2
 				asl.l	#7,d2
-				sub.l	PLR1_yoff,d2
+				sub.l	Plr1_YOff_l,d2
 				move.l	d2,d3
 				bge.s	.oknotneg
 				neg.l	d2
@@ -133,7 +133,7 @@ outofline:
 				move.w	d1,targdist
 
 				move.l	targetydiff,d5
-				sub.l	PLR1_height,d5
+				sub.l	Plr1_Height_l,d5
 				add.l	#18*256,d5
 				move.w	d1,closedist
 
@@ -226,10 +226,10 @@ FIREBULLETS:
 
 				and.w	#$7fff,d0
 				move.w	(a1),d1
-				sub.w	PLR1_xoff,d1
+				sub.w	Plr1_XOff_l,d1
 				muls	d1,d1
 				move.w	4(a1),d2
-				sub.w	PLR1_zoff,d2
+				sub.w	Plr1_ZOff_l,d2
 				muls	d2,d2
 				add.l	d2,d1
 				asr.l	#6,d1
@@ -271,17 +271,17 @@ nothingtoshoot:
 
 				move.w	#0,bulyspd
 
-				move.w	PLR1_xoff,oldx
-				move.w	PLR1_zoff,oldz
-				move.w	PLR1_sinval,d0
+				move.w	Plr1_XOff_l,oldx
+				move.w	Plr1_ZOff_l,oldz
+				move.w	Plr1_SinVal_w,d0
 				asr.w	#7,d0
 				add.w	oldx,d0
 				move.w	d0,newx
-				move.w	PLR1_cosval,d0
+				move.w	Plr1_CosVal_w,d0
 				asr.w	#7,d0
 				add.w	oldz,d0
 				move.w	d0,newz
-				move.l	PLR1_yoff,d0
+				move.l	Plr1_YOff_l,d0
 				add.l	#10*128,d0
 				move.l	d0,oldy
 
@@ -302,7 +302,7 @@ nothingtoshoot:
 				move.l	#0,StepUpVal
 				move.l	#$1000000,StepDownVal
 				move.l	#0,thingheight
-				move.l	PLR1_Roompt,objroom
+				move.l	Plr1_RoomPtr_l,objroom
 				movem.l	d0-d7/a0-a6,-(a7)
 
 .again:
@@ -885,9 +885,9 @@ PLR1HITINSTANT:
 
 PLR1MISSINSTANT:
 
-				move.w	PLR1_xoff,oldx
-				move.w	PLR1_zoff,oldz
-				move.l	PLR1_yoff,d1
+				move.w	Plr1_XOff_l,oldx
+				move.w	Plr1_ZOff_l,oldz
+				move.l	Plr1_YOff_l,d1
 				add.l	#10*128,d1
 				move.l	d1,oldy
 
@@ -917,7 +917,7 @@ PLR1MISSINSTANT:
 				move.l	#0,StepUpVal
 				move.l	#$1000000,StepDownVal
 				move.l	#0,thingheight
-				move.l	PLR1_Roompt,objroom
+				move.l	Plr1_RoomPtr_l,objroom
 				movem.l	d0-d7/a0-a6,-(a7)
 
 .again:

--- a/ab3d2_source/newplayershoot.s
+++ b/ab3d2_source/newplayershoot.s
@@ -27,7 +27,7 @@ Player1Shot:
 okcanfire:
 
 				moveq	#0,d0
-				move.b	p1_gunselected,d0
+				move.b	Plr1_TmpGunSelected_b,d0
 				move.b	d0,tempgun
 
 
@@ -48,12 +48,12 @@ okcanfire:
 ; tst.w (a6)
 ; beq.s .itsaclick
 
-				tst.b	p1_fire
+				tst.b	Plr1_TmpFire_b
 				beq		PLR1_nofire
 ; bra .itsahold
 ;
 ;.itsaclick:
-; tst.b p1_clicked
+; tst.b Plr1_TmpClicked_b
 ; beq PLR1_nofire
 ;
 ;.itsahold:
@@ -378,7 +378,7 @@ Player2Shot:
 okcanfire2:
 
 				moveq	#0,d0
-				move.b	p2_gunselected,d0
+				move.b	Plr2_TmpGunSelected_b,d0
 				move.b	d0,tempgun
 
 
@@ -399,28 +399,28 @@ okcanfire2:
 ; tst.w 12(a6)
 ; beq.s .itsaclick
 
-				tst.b	p2_fire
+				tst.b	Plr2_TmpFire_b
 				beq		PLR2_nofire
 ; bra .itsahold
 ;
 ;.itsaclick:
-; tst.b p2_clicked
+; tst.b Plr2_TmpClicked_b
 ; beq PLR2_nofire
 ;
 ;.itsahold:
 
-				move.w	PLR2_angpos,d0
+				move.w	Plr2_AngPos_w,d0
 				move.w	d0,tempangpos
 				move.l	#SineTable,a0
 				lea		(a0,d0.w),a0
 				move.w	(a0),tempxdir
 				move.w	2048(a0),tempzdir
-				move.w	PLR2_xoff,tempxoff
-				move.w	PLR2_zoff,tempzoff
-				move.l	PLR2_yoff,tempyoff
+				move.w	Plr2_XOff_l,tempxoff
+				move.w	Plr2_ZOff_l,tempzoff
+				move.l	Plr2_YOff_l,tempyoff
 				add.l	#10*128,tempyoff
-				move.b	PLR2_StoodInTop,tempStoodInTop
-				move.l	PLR2_Roompt,tempRoompt
+				move.b	Plr2_StoodInTop_b,tempStoodInTop
+				move.l	Plr2_RoomPtr_l,tempRoompt
 				move.l	#%10011,d7
 				move.w	#-1,d0
 				move.l	#0,targetydiff
@@ -456,7 +456,7 @@ findclosestinline2
 				move.w	4(a0),d2
 				ext.l	d2
 				asl.l	#7,d2
-				sub.l	PLR2_yoff,d2
+				sub.l	Plr2_YOff_l,d2
 				move.l	d2,d3
 				bge.s	.oknotneg
 				neg.l	d2
@@ -484,7 +484,7 @@ outofline2:
 				move.w	d1,targdist
 
 				move.l	targetydiff,d5
-				sub.l	PLR2_height,d5
+				sub.l	Plr2_Height_l,d5
 				add.l	#18*256,d5
 				move.w	d1,closedist
 
@@ -577,10 +577,10 @@ FIREBULLETS2:
 
 				and.w	#$7fff,d0
 				move.w	(a1),d1
-				sub.w	PLR2_xoff,d1
+				sub.w	Plr2_XOff_l,d1
 				muls	d1,d1
 				move.w	4(a1),d2
-				sub.w	PLR2_zoff,d2
+				sub.w	Plr2_ZOff_l,d2
 				muls	d2,d2
 				add.l	d2,d1
 				asr.l	#6,d1
@@ -622,17 +622,17 @@ nothingtoshoot2:
 
 				move.w	#0,bulyspd
 
-				move.w	PLR2_xoff,oldx
-				move.w	PLR2_zoff,oldz
-				move.w	PLR2_sinval,d0
+				move.w	Plr2_XOff_l,oldx
+				move.w	Plr2_ZOff_l,oldz
+				move.w	Plr2_SinVal_w,d0
 				asr.w	#7,d0
 				add.w	oldx,d0
 				move.w	d0,newx
-				move.w	PLR2_cosval,d0
+				move.w	Plr2_CosVal_w,d0
 				asr.w	#7,d0
 				add.w	oldz,d0
 				move.w	d0,newz
-				move.l	PLR2_yoff,d0
+				move.l	Plr2_YOff_l,d0
 				add.l	#10*128,d0
 				move.l	d0,oldy
 
@@ -653,7 +653,7 @@ nothingtoshoot2:
 				move.l	#0,StepUpVal
 				move.l	#$1000000,StepDownVal
 				move.l	#0,thingheight
-				move.l	PLR2_Roompt,objroom
+				move.l	Plr2_RoomPtr_l,objroom
 				movem.l	d0-d7/a0-a6,-(a7)
 
 .again:
@@ -1027,9 +1027,9 @@ PLR2HITINSTANT:
 
 PLR2MISSINSTANT:
 
-				move.w	PLR2_xoff,oldx
-				move.w	PLR2_zoff,oldz
-				move.l	PLR2_yoff,d1
+				move.w	Plr2_XOff_l,oldx
+				move.w	Plr2_ZOff_l,oldz
+				move.l	Plr2_YOff_l,d1
 				add.l	#10*128,d1
 				move.l	d1,oldy
 
@@ -1059,7 +1059,7 @@ PLR2MISSINSTANT:
 				move.l	#0,StepUpVal
 				move.l	#$1000000,StepDownVal
 				move.l	#0,thingheight
-				move.l	PLR2_Roompt,objroom
+				move.l	Plr2_RoomPtr_l,objroom
 				movem.l	d0-d7/a0-a6,-(a7)
 
 .again:

--- a/ab3d2_source/objdrawhires.s
+++ b/ab3d2_source/objdrawhires.s
@@ -1583,8 +1583,8 @@ INMIDDLE:
 ; brightnesses.
 
 
-; move.w PLR1_xoff,newx
-; move.w PLR1_zoff,newz
+; move.w Plr1_XOff_l,newx
+; move.w Plr1_ZOff_l,newz
 ; move.w thisxpos,oldx
 ; move.w thiszpos,oldz
 ; movem.l d0-d7/a0-a6,-(a7)

--- a/ab3d2_source/objdrawhires.s
+++ b/ab3d2_source/objdrawhires.s
@@ -1552,7 +1552,7 @@ INMIDDLE:
 				muls	#7*16,d2
 				add.l	d2,a1
 
-				move.w	p1_angpos,d0
+				move.w	Plr1_TmpAngPos_w,d0
 				neg.w	d0
 				add.w	#4096,d0
 				and.w	#8191,d0
@@ -1594,7 +1594,7 @@ INMIDDLE:
 
 ; move.w #0,d0
 ; move.w AngRet,d0
-; move.w p1_angpos,d0
+; move.w Plr1_TmpAngPos_w,d0
 ; neg.w d0
 ; add.w #4096,d0
 ; and.w #8191,d0

--- a/ab3d2_source/pauseopts.s
+++ b/ab3d2_source/pauseopts.s
@@ -44,12 +44,12 @@
 
 				cmp.b	#'s',mors
 				beq.s	.otherk
-				tst.b	PLR1JOY
+				tst.b	Plr1_Joystick_b
 				beq.s	.NOJOY
 				jsr		_ReadJoy1
 				bra		.thisk
 .otherk:
-				tst.b	PLR2JOY
+				tst.b	Plr2_Joystick_b
 				beq.s	.NOJOY
 				jsr		_ReadJoy2
 .thisk:
@@ -65,12 +65,12 @@
 
 				cmp.b	#'s',mors
 				beq.s	.otherk2
-				tst.b	PLR1JOY
+				tst.b	Plr1_Joystick_b
 				beq.s	.NOJOY2
 				jsr		_ReadJoy1
 				bra		.thisk2
 .otherk2:
-				tst.b	PLR2JOY
+				tst.b	Plr2_Joystick_b
 				beq.s	.NOJOY2
 				jsr		_ReadJoy2
 .thisk2:
@@ -113,11 +113,11 @@ CHECKUPDOWN
 
 				cmp.b	#'s',mors
 				beq.s	.slavechk
-				tst.b	PLR1JOY
+				tst.b	Plr1_Joystick_b
 				bne.s	.nofing
 				bra.s	.maschk
 .slavechk:
-				tst.b	PLR2JOY
+				tst.b	Plr2_Joystick_b
 				bne.s	.nofing
 
 .maschk:

--- a/ab3d2_source/plr1control.s
+++ b/ab3d2_source/plr1control.s
@@ -3,16 +3,16 @@ PLR1_mouse_control
 				jsr		ReadMouse
 
 				move.l	#SineTable,a0
-				move.w	Plr1_AltAngSpd_w,d1
+				move.w	Plr1_SnapAngSpd_w,d1
 				move.w	angpos,d0
 				and.w	#8190,d0
-				move.w	d0,Plr1_AltAngPos_w
-				move.w	(a0,d0.w),Plr1_AltSinVal_w
+				move.w	d0,Plr1_SnapAngPos_w
+				move.w	(a0,d0.w),Plr1_SnapSinVal_w
 				adda.w	#2048,a0
-				move.w	(a0,d0.w),Plr1_AltCosVal_w
+				move.w	(a0,d0.w),Plr1_SnapCosVal_w
 
-				move.l	Plr1_AltXSpdVal_l,d6
-				move.l	Plr1_AltZSpdVal_l,d7
+				move.l	Plr1_SnapXSpdVal_l,d6
+				move.l	Plr1_SnapZSpdVal_l,d7
 
 				neg.l	d6
 				ble.s	.nobug1
@@ -107,8 +107,8 @@ PLR1_mouse_control
 
 				move.w	d1,ADDTOBOBBLE
 
-				move.w	Plr1_AltSinVal_w,d1
-				move.w	Plr1_AltCosVal_w,d2
+				move.w	Plr1_SnapSinVal_w,d1
+				move.w	Plr1_SnapCosVal_w,d2
 
 				move.w	d2,d4
 				move.w	d1,d5
@@ -122,12 +122,12 @@ PLR1_mouse_control
 
 				sub.l	d1,d6
 				sub.l	d2,d7
-				add.l	d6,Plr1_AltXSpdVal_l
-				add.l	d7,Plr1_AltZSpdVal_l
-				move.l	Plr1_AltXSpdVal_l,d6
-				move.l	Plr1_AltZSpdVal_l,d7
-				add.l	d6,Plr1_AltXOff_l
-				add.l	d7,Plr1_AltZOff_l
+				add.l	d6,Plr1_SnapXSpdVal_l
+				add.l	d7,Plr1_SnapZSpdVal_l
+				move.l	Plr1_SnapXSpdVal_l,d6
+				move.l	Plr1_SnapZSpdVal_l,d7
+				add.l	d6,Plr1_SnapXOff_l
+				add.l	d7,Plr1_SnapZOff_l
 
 				tst.b	PLR1_fire
 				beq.s	.firenotpressed
@@ -167,9 +167,9 @@ PLR1_follow_path:
 
 				move.l	pathpt,a0
 				move.w	(a0),d1
-				move.w	d1,Plr1_AltXOff_l
+				move.w	d1,Plr1_SnapXOff_l
 				move.w	2(a0),d1
-				move.w	d1,Plr1_AltZOff_l
+				move.w	d1,Plr1_SnapZOff_l
 				move.w	4(a0),d0
 				add.w	d0,d0
 				and.w	#8190,d0
@@ -206,7 +206,7 @@ PLR1_alwayskeys
 				st		gunheldlast
 
 				moveq	#0,d0
-				move.b	Plr1_GunSelected_w,d0
+				move.b	Plr1_GunSelected_b,d0
 				move.l	#PLAYERONEGUNS,a0
 
 .findnext
@@ -218,7 +218,7 @@ PLR1_alwayskeys
 				tst.w	(a0,d0.w*2)
 				beq.s	.findnext
 
-				move.b	d0,Plr1_GunSelected_w
+				move.b	d0,Plr1_GunSelected_b
 				bsr		SHOWPLR1GUNNAME
 
 				bra		.nonextweap
@@ -241,10 +241,10 @@ nottapped:
 				tst.b	(a5,d7.w)
 				beq.s	notduck
 				clr.b	(a5,d7.w)
-				move.l	#playerheight,Plr1_AltTargHeight_l
+				move.l	#playerheight,Plr1_SnapTargHeight_l
 				not.b	PLR1_Ducked
 				beq.s	notduck
-				move.l	#playercrouched,Plr1_AltTargHeight_l
+				move.l	#playercrouched,Plr1_SnapTargHeight_l
 notduck:
 
 				move.l	Plr1_RoomPtr_l,a4
@@ -265,14 +265,14 @@ usebottom:
 				move.l	#playercrouched,PLR1s_SquishedHeight
 oktostand:
 
-				move.l	Plr1_AltTargHeight_l,d1
+				move.l	Plr1_SnapTargHeight_l,d1
 				move.l	PLR1s_SquishedHeight,d0
 				cmp.l	d0,d1
 				blt.s	.notsqu
 				move.l	d0,d1
 .notsqu:
 
-				move.l	Plr1_AltHeight_l,d0
+				move.l	Plr1_SnapHeight_l,d0
 				cmp.l	d1,d0
 				beq.s	noupordown
 				bgt.s	crouch
@@ -281,7 +281,7 @@ oktostand:
 crouch:
 				sub.l	#1024,d0
 noupordown:
-				move.l	d0,Plr1_AltHeight_l
+				move.l	d0,Plr1_SnapHeight_l
 
 				tst.b	$27(a5)
 				beq.s	notselkey
@@ -316,7 +316,7 @@ pickweap
 				move.w	(a2)+,d0
 				and.b	(a4)+,d0
 				beq.s	notgotweap
-				move.b	d2,Plr1_GunSelected_w
+				move.b	d2,Plr1_GunSelected_b
 				move.w	#0,EntT_Timer1_w+128(a3)
 
 
@@ -407,7 +407,7 @@ WIPEDISPLAY:
 
 SHOWPLR1GUNNAME:
 				moveq	#0,d2
-				move.b	Plr1_GunSelected_w,d2
+				move.b	Plr1_GunSelected_b,d2
 
 				move.l	GLF_DatabasePtr_l,a4
 				add.l	#GLFT_GunNames_l,a4
@@ -491,8 +491,8 @@ PLR1_keyboard_control:
 				muls	#SCREENWIDTH,d0
 				move.l	d0,SBIGMIDDLEY
 
-				move.w	Plr1_AltAngPos_w,d0
-				move.w	Plr1_AltAngSpd_w,d3
+				move.w	Plr1_SnapAngPos_w,d0
+				move.w	Plr1_SnapAngSpd_w,d3
 				move.w	#35,d1
 				move.w	#2,d2
 				move.w	#10,TURNSPD
@@ -571,7 +571,7 @@ noturnposs:
 
 				add.w	d3,d0
 				add.w	d3,d0
-				move.w	d3,Plr1_AltAngSpd_w
+				move.w	d3,Plr1_SnapAngSpd_w
 
 				move.b	tempslkey,d7
 				tst.b	(a5,d7.w)
@@ -593,14 +593,14 @@ norightslide
 noslide:
 
 				and.w	#8191,d0
-				move.w	d0,Plr1_AltAngPos_w
+				move.w	d0,Plr1_SnapAngPos_w
 
-				move.w	(a0,d0.w),Plr1_AltSinVal_w
+				move.w	(a0,d0.w),Plr1_SnapSinVal_w
 				adda.w	#2048,a0
-				move.w	(a0,d0.w),Plr1_AltCosVal_w
+				move.w	(a0,d0.w),Plr1_SnapCosVal_w
 
-				move.l	Plr1_AltXSpdVal_l,d6
-				move.l	Plr1_AltZSpdVal_l,d7
+				move.l	Plr1_SnapXSpdVal_l,d6
+				move.l	Plr1_SnapZSpdVal_l,d7
 
 				tst.b	SLOWDOWN
 				beq.s	.nofriction
@@ -648,29 +648,29 @@ nobackward:
 ; add.w d2,d1
 				move.w	d1,ADDTOBOBBLE
 
-				move.w	Plr1_AltSinVal_w,d1
+				move.w	Plr1_SnapSinVal_w,d1
 				muls	d3,d1
-				move.w	Plr1_AltCosVal_w,d2
+				move.w	Plr1_SnapCosVal_w,d2
 				muls	d3,d2
 
 				sub.l	d1,d6
 				sub.l	d2,d7
-				move.w	Plr1_AltSinVal_w,d1
+				move.w	Plr1_SnapSinVal_w,d1
 				muls	d4,d1
-				move.w	Plr1_AltCosVal_w,d2
+				move.w	Plr1_SnapCosVal_w,d2
 				muls	d4,d2
 				sub.l	d2,d6
 				add.l	d1,d7
 
 				tst.b	SLOWDOWN
 				beq.s	.nocontrolposs
-				add.l	d6,Plr1_AltXSpdVal_l
-				add.l	d7,Plr1_AltZSpdVal_l
+				add.l	d6,Plr1_SnapXSpdVal_l
+				add.l	d7,Plr1_SnapZSpdVal_l
 .nocontrolposs
-				move.l	Plr1_AltXSpdVal_l,d6
-				move.l	Plr1_AltZSpdVal_l,d7
-				add.l	d6,Plr1_AltXOff_l
-				add.l	d7,Plr1_AltZOff_l
+				move.l	Plr1_SnapXSpdVal_l,d6
+				move.l	Plr1_SnapZSpdVal_l,d7
+				add.l	d6,Plr1_SnapXOff_l
+				add.l	d7,Plr1_SnapZOff_l
 
 				move.b	fire_key,d5
 				tst.b	PLR1_fire

--- a/ab3d2_source/plr1control.s
+++ b/ab3d2_source/plr1control.s
@@ -3,16 +3,16 @@ PLR1_mouse_control
 				jsr		ReadMouse
 
 				move.l	#SineTable,a0
-				move.w	PLR1s_angspd,d1
+				move.w	Plr1_AltAngSpd_w,d1
 				move.w	angpos,d0
 				and.w	#8190,d0
-				move.w	d0,PLR1s_angpos
-				move.w	(a0,d0.w),PLR1s_sinval
+				move.w	d0,Plr1_AltAngPos_w
+				move.w	(a0,d0.w),Plr1_AltSinVal_w
 				adda.w	#2048,a0
-				move.w	(a0,d0.w),PLR1s_cosval
+				move.w	(a0,d0.w),Plr1_AltCosVal_w
 
-				move.l	PLR1s_xspdval,d6
-				move.l	PLR1s_zspdval,d7
+				move.l	Plr1_AltXSpdVal_l,d6
+				move.l	Plr1_AltZSpdVal_l,d7
 
 				neg.l	d6
 				ble.s	.nobug1
@@ -107,8 +107,8 @@ PLR1_mouse_control
 
 				move.w	d1,ADDTOBOBBLE
 
-				move.w	PLR1s_sinval,d1
-				move.w	PLR1s_cosval,d2
+				move.w	Plr1_AltSinVal_w,d1
+				move.w	Plr1_AltCosVal_w,d2
 
 				move.w	d2,d4
 				move.w	d1,d5
@@ -122,12 +122,12 @@ PLR1_mouse_control
 
 				sub.l	d1,d6
 				sub.l	d2,d7
-				add.l	d6,PLR1s_xspdval
-				add.l	d7,PLR1s_zspdval
-				move.l	PLR1s_xspdval,d6
-				move.l	PLR1s_zspdval,d7
-				add.l	d6,PLR1s_xoff
-				add.l	d7,PLR1s_zoff
+				add.l	d6,Plr1_AltXSpdVal_l
+				add.l	d7,Plr1_AltZSpdVal_l
+				move.l	Plr1_AltXSpdVal_l,d6
+				move.l	Plr1_AltZSpdVal_l,d7
+				add.l	d6,Plr1_AltXOff_l
+				add.l	d7,Plr1_AltZOff_l
 
 				tst.b	PLR1_fire
 				beq.s	.firenotpressed
@@ -167,13 +167,13 @@ PLR1_follow_path:
 
 				move.l	pathpt,a0
 				move.w	(a0),d1
-				move.w	d1,PLR1s_xoff
+				move.w	d1,Plr1_AltXOff_l
 				move.w	2(a0),d1
-				move.w	d1,PLR1s_zoff
+				move.w	d1,Plr1_AltZOff_l
 				move.w	4(a0),d0
 				add.w	d0,d0
 				and.w	#8190,d0
-				move.w	d0,PLR1_angpos
+				move.w	d0,Plr1_AngPos_w
 
 				move.w	TempFrames,d0
 				asl.w	#3,d0
@@ -206,7 +206,7 @@ PLR1_alwayskeys
 				st		gunheldlast
 
 				moveq	#0,d0
-				move.b	PLR1_GunSelected,d0
+				move.b	Plr1_GunSelected_w,d0
 				move.l	#PLAYERONEGUNS,a0
 
 .findnext
@@ -218,7 +218,7 @@ PLR1_alwayskeys
 				tst.w	(a0,d0.w*2)
 				beq.s	.findnext
 
-				move.b	d0,PLR1_GunSelected
+				move.b	d0,Plr1_GunSelected_w
 				bsr		SHOWPLR1GUNNAME
 
 				bra		.nonextweap
@@ -241,16 +241,16 @@ nottapped:
 				tst.b	(a5,d7.w)
 				beq.s	notduck
 				clr.b	(a5,d7.w)
-				move.l	#playerheight,PLR1s_targheight
+				move.l	#playerheight,Plr1_AltTargHeight_l
 				not.b	PLR1_Ducked
 				beq.s	notduck
-				move.l	#playercrouched,PLR1s_targheight
+				move.l	#playercrouched,Plr1_AltTargHeight_l
 notduck:
 
-				move.l	PLR1_Roompt,a4
+				move.l	Plr1_RoomPtr_l,a4
 				move.l	ZoneT_Floor_l(a4),d0
 				sub.l	ZoneT_Roof_l(a4),d0
-				tst.b	PLR1_StoodInTop
+				tst.b	Plr1_StoodInTop_b
 				beq.s	usebottom
 				move.l	ZoneT_UpperFloor_l(a4),d0
 				sub.l	ZoneT_UpperRoof_l(a4),d0
@@ -265,14 +265,14 @@ usebottom:
 				move.l	#playercrouched,PLR1s_SquishedHeight
 oktostand:
 
-				move.l	PLR1s_targheight,d1
+				move.l	Plr1_AltTargHeight_l,d1
 				move.l	PLR1s_SquishedHeight,d0
 				cmp.l	d0,d1
 				blt.s	.notsqu
 				move.l	d0,d1
 .notsqu:
 
-				move.l	PLR1s_height,d0
+				move.l	Plr1_AltHeight_l,d0
 				cmp.l	d1,d0
 				beq.s	noupordown
 				bgt.s	crouch
@@ -281,30 +281,30 @@ oktostand:
 crouch:
 				sub.l	#1024,d0
 noupordown:
-				move.l	d0,PLR1s_height
+				move.l	d0,Plr1_AltHeight_l
 
 				tst.b	$27(a5)
 				beq.s	notselkey
-				st		PLR1KEYS
-				clr.b	PLR1PATH
-				clr.b	PLR1MOUSE
-				clr.b	PLR1JOY
+				st		Plr1_Keys_b
+				clr.b	Plr1_Path_b
+				clr.b	Plr1_Mouse_b
+				clr.b	Plr1_Joystick_b
 notselkey:
 
 				tst.b	$26(a5)
 				beq.s	notseljoy
-				clr.b	PLR1KEYS
-				clr.b	PLR1PATH
-				clr.b	PLR1MOUSE
-				st		PLR1JOY
+				clr.b	Plr1_Keys_b
+				clr.b	Plr1_Path_b
+				clr.b	Plr1_Mouse_b
+				st		Plr1_Joystick_b
 notseljoy:
 
 				tst.b	$37(a5)
 				beq.s	notselmouse
-				clr.b	PLR1KEYS
-				clr.b	PLR1PATH
-				st		PLR1MOUSE
-				clr.b	PLR1JOY
+				clr.b	Plr1_Keys_b
+				clr.b	Plr1_Path_b
+				st		Plr1_Mouse_b
+				clr.b	Plr1_Joystick_b
 notselmouse:
 
 				lea		1(a5),a4
@@ -316,7 +316,7 @@ pickweap
 				move.w	(a2)+,d0
 				and.b	(a4)+,d0
 				beq.s	notgotweap
-				move.b	d2,PLR1_GunSelected
+				move.b	d2,Plr1_GunSelected_w
 				move.w	#0,EntT_Timer1_w+128(a3)
 
 
@@ -407,7 +407,7 @@ WIPEDISPLAY:
 
 SHOWPLR1GUNNAME:
 				moveq	#0,d2
-				move.b	PLR1_GunSelected,d2
+				move.b	Plr1_GunSelected_w,d2
 
 				move.l	GLF_DatabasePtr_l,a4
 				add.l	#GLFT_GunNames_l,a4
@@ -491,8 +491,8 @@ PLR1_keyboard_control:
 				muls	#SCREENWIDTH,d0
 				move.l	d0,SBIGMIDDLEY
 
-				move.w	PLR1s_angpos,d0
-				move.w	PLR1s_angspd,d3
+				move.w	Plr1_AltAngPos_w,d0
+				move.w	Plr1_AltAngSpd_w,d3
 				move.w	#35,d1
 				move.w	#2,d2
 				move.w	#10,TURNSPD
@@ -571,7 +571,7 @@ noturnposs:
 
 				add.w	d3,d0
 				add.w	d3,d0
-				move.w	d3,PLR1s_angspd
+				move.w	d3,Plr1_AltAngSpd_w
 
 				move.b	tempslkey,d7
 				tst.b	(a5,d7.w)
@@ -593,14 +593,14 @@ norightslide
 noslide:
 
 				and.w	#8191,d0
-				move.w	d0,PLR1s_angpos
+				move.w	d0,Plr1_AltAngPos_w
 
-				move.w	(a0,d0.w),PLR1s_sinval
+				move.w	(a0,d0.w),Plr1_AltSinVal_w
 				adda.w	#2048,a0
-				move.w	(a0,d0.w),PLR1s_cosval
+				move.w	(a0,d0.w),Plr1_AltCosVal_w
 
-				move.l	PLR1s_xspdval,d6
-				move.l	PLR1s_zspdval,d7
+				move.l	Plr1_AltXSpdVal_l,d6
+				move.l	Plr1_AltZSpdVal_l,d7
 
 				tst.b	SLOWDOWN
 				beq.s	.nofriction
@@ -648,29 +648,29 @@ nobackward:
 ; add.w d2,d1
 				move.w	d1,ADDTOBOBBLE
 
-				move.w	PLR1s_sinval,d1
+				move.w	Plr1_AltSinVal_w,d1
 				muls	d3,d1
-				move.w	PLR1s_cosval,d2
+				move.w	Plr1_AltCosVal_w,d2
 				muls	d3,d2
 
 				sub.l	d1,d6
 				sub.l	d2,d7
-				move.w	PLR1s_sinval,d1
+				move.w	Plr1_AltSinVal_w,d1
 				muls	d4,d1
-				move.w	PLR1s_cosval,d2
+				move.w	Plr1_AltCosVal_w,d2
 				muls	d4,d2
 				sub.l	d2,d6
 				add.l	d1,d7
 
 				tst.b	SLOWDOWN
 				beq.s	.nocontrolposs
-				add.l	d6,PLR1s_xspdval
-				add.l	d7,PLR1s_zspdval
+				add.l	d6,Plr1_AltXSpdVal_l
+				add.l	d7,Plr1_AltZSpdVal_l
 .nocontrolposs
-				move.l	PLR1s_xspdval,d6
-				move.l	PLR1s_zspdval,d7
-				add.l	d6,PLR1s_xoff
-				add.l	d7,PLR1s_zoff
+				move.l	Plr1_AltXSpdVal_l,d6
+				move.l	Plr1_AltZSpdVal_l,d7
+				add.l	d6,Plr1_AltXOff_l
+				add.l	d7,Plr1_AltZOff_l
 
 				move.b	fire_key,d5
 				tst.b	PLR1_fire
@@ -721,17 +721,17 @@ PLR1_clumptime:	dc.w	0
 PLR1clump:
 
 				movem.l	d0-d7/a0-a6,-(a7)
-				move.l	PLR1_Roompt,a0
+				move.l	Plr1_RoomPtr_l,a0
 				move.w	ZoneT_FloorNoise_w(a0),d0
 
 				move.l	ZoneT_Water_l(a0),d1
 				cmp.l	ZoneT_Floor_l(a0),d1
 				bge.s	THERESNOWATER
 
-				cmp.l	PLR1_yoff,d1
+				cmp.l	Plr1_YOff_l,d1
 				blt.s	THERESNOWATER
 
-				tst.b	PLR1_StoodInTop
+				tst.b	Plr1_StoodInTop_b
 				bne.s	THERESNOWATER
 
 				move.w	#6,d0
@@ -739,7 +739,7 @@ PLR1clump:
 
 THERESNOWATER:
 
-				tst.b	PLR1_StoodInTop
+				tst.b	Plr1_StoodInTop_b
 				beq.s	.okinbot
 				move.w	ZoneT_UpperFloorNoise_w(a0),d0
 .okinbot:
@@ -758,7 +758,7 @@ THERESWATER:
 				move.w	#80,Noisevol
 				move.w	#$fff8,IDNUM
 				clr.b	notifplaying
-				move.b	PLR1_Echo,SourceEcho
+				move.b	Plr1_Echo_b,SourceEcho
 				jsr		MakeSomeNoise
 
 nofootsound:

--- a/ab3d2_source/plr1control.s
+++ b/ab3d2_source/plr1control.s
@@ -88,9 +88,9 @@ PLR1_mouse_control
 
 				move.w	#-20,d2
 
-				tst.b	PLR1_Squished
+				tst.b	Plr1_Squished_b
 				bne.s	.halve
-				tst.b	PLR1_Ducked
+				tst.b	Plr1_Ducked_b
 				beq.s	.nohalve
 .halve
 				asr.w	#1,d2
@@ -242,7 +242,7 @@ nottapped:
 				beq.s	notduck
 				clr.b	(a5,d7.w)
 				move.l	#playerheight,Plr1_SnapTargHeight_l
-				not.b	PLR1_Ducked
+				not.b	Plr1_Ducked_b
 				beq.s	notduck
 				move.l	#playercrouched,Plr1_SnapTargHeight_l
 notduck:
@@ -256,17 +256,17 @@ notduck:
 				sub.l	ZoneT_UpperRoof_l(a4),d0
 usebottom:
 
-				clr.b	PLR1_Squished
-				move.l	#playerheight,PLR1s_SquishedHeight
+				clr.b	Plr1_Squished_b
+				move.l	#playerheight,Plr1_SnapSquishedHeight_l
 
 				cmp.l	#playerheight+3*1024,d0
 				bgt.s	oktostand
-				st		PLR1_Squished
-				move.l	#playercrouched,PLR1s_SquishedHeight
+				st		Plr1_Squished_b
+				move.l	#playercrouched,Plr1_SnapSquishedHeight_l
 oktostand:
 
 				move.l	Plr1_SnapTargHeight_l,d1
-				move.l	PLR1s_SquishedHeight,d0
+				move.l	Plr1_SnapSquishedHeight_l,d0
 				cmp.l	d0,d1
 				blt.s	.notsqu
 				move.l	d0,d1
@@ -504,9 +504,9 @@ PLR1_keyboard_control:
 				move.w	#3,d2
 				move.w	#14,TURNSPD
 nofaster:
-				tst.b	PLR1_Squished
+				tst.b	Plr1_Squished_b
 				bne.s	.halve
-				tst.b	PLR1_Ducked
+				tst.b	Plr1_Ducked_b
 				beq.s	.nohalve
 .halve
 				asr.w	#1,d2

--- a/ab3d2_source/plr2control.s
+++ b/ab3d2_source/plr2control.s
@@ -84,9 +84,9 @@ PLR2_mouse_control
 
 				move.w	#-20,d2
 
-				tst.b	PLR2_Squished
+				tst.b	Plr2_Squished_b
 				bne.s	.halve
-				tst.b	PLR2_Ducked
+				tst.b	Plr2_Ducked_b
 				beq.s	.nohalve
 .halve
 				asr.w	#1,d2
@@ -235,7 +235,7 @@ PLR2_alwayskeys
 				beq.s	.notduck
 				clr.b	(a5,d7.w)
 				move.l	#playerheight,Plr2_SnapTargHeight_l
-				not.b	PLR2_Ducked
+				not.b	Plr2_Ducked_b
 				beq.s	.notduck
 				move.l	#playercrouched,Plr2_SnapTargHeight_l
 .notduck:
@@ -249,17 +249,17 @@ PLR2_alwayskeys
 				sub.l	ZoneT_UpperRoof_l(a4),d0
 .usebottom:
 
-				clr.b	PLR2_Squished
-				move.l	#playerheight,PLR2s_SquishedHeight
+				clr.b	Plr2_Squished_b
+				move.l	#playerheight,Plr2_SnapSquishedHeight_l
 
 				cmp.l	#playerheight+3*1024,d0
 				bgt.s	oktostand2
-				st		PLR2_Squished
-				move.l	#playercrouched,PLR2s_SquishedHeight
+				st		Plr2_Squished_b
+				move.l	#playercrouched,Plr2_SnapSquishedHeight_l
 oktostand2:
 
 				move.l	Plr2_SnapTargHeight_l,d1
-				move.l	PLR2s_SquishedHeight,d0
+				move.l	Plr2_SnapSquishedHeight_l,d0
 				cmp.l	d0,d1
 				blt.s	.notsqu
 				move.l	d0,d1
@@ -482,9 +482,9 @@ PLR2_keyboard_control:
 				move.w	#3,d2
 				move.w	#14,TURNSPD
 .nofaster:
-				tst.b	PLR2_Squished
+				tst.b	Plr2_Squished_b
 				bne.s	.halve
-				tst.b	PLR2_Ducked
+				tst.b	Plr2_Ducked_b
 				beq.s	.nohalve
 .halve:
 				asr.w	#1,d2

--- a/ab3d2_source/plr2control.s
+++ b/ab3d2_source/plr2control.s
@@ -278,26 +278,26 @@ oktostand2:
 
 				tst.b	$27(a5)
 				beq.s	.notselkey
-				st		PLR2KEYS
-				clr.b	PLR2PATH
-				clr.b	PLR2MOUSE
-				clr.b	PLR2JOY
+				st		Plr2_Keys_b
+				clr.b	Plr2_Path_b
+				clr.b	Plr2_Mouse_b
+				clr.b	Plr2_Joystick_b
 .notselkey:
 
 				tst.b	$26(a5)
 				beq.s	.notseljoy
-				clr.b	PLR2KEYS
-				clr.b	PLR2PATH
-				clr.b	PLR2MOUSE
-				st		PLR2JOY
+				clr.b	Plr2_Keys_b
+				clr.b	Plr2_Path_b
+				clr.b	Plr2_Mouse_b
+				st		Plr2_Joystick_b
 .notseljoy:
 
 				tst.b	$37(a5)
 				beq.s	.notselmouse
-				clr.b	PLR2KEYS
-				clr.b	PLR2PATH
-				st		PLR2MOUSE
-				clr.b	PLR2JOY
+				clr.b	Plr2_Keys_b
+				clr.b	Plr2_Path_b
+				st		Plr2_Mouse_b
+				clr.b	Plr2_Joystick_b
 .notselmouse:
 
 				lea		1(a5),a4

--- a/ab3d2_source/plr2control.s
+++ b/ab3d2_source/plr2control.s
@@ -3,16 +3,16 @@ PLR2_mouse_control
 				jsr		ReadMouse
 
 				move.l	#SineTable,a0
-				move.w	PLR2s_angspd,d1
+				move.w	Plr2_SnapAngSpd_w,d1
 				move.w	angpos,d0
 				and.w	#8190,d0
-				move.w	d0,PLR2s_angpos
-				move.w	(a0,d0.w),PLR2s_sinval
+				move.w	d0,Plr2_SnapAngPos_w
+				move.w	(a0,d0.w),Plr2_SnapSinVal_w
 				adda.w	#2048,a0
-				move.w	(a0,d0.w),PLR2s_cosval
+				move.w	(a0,d0.w),Plr2_SnapCosVal_w
 
-				move.l	PLR2s_xspdval,d6
-				move.l	PLR2s_zspdval,d7
+				move.l	Plr2_SnapXSpdVal_l,d6
+				move.l	Plr2_SnapZSpdVal_l,d7
 
 				neg.l	d6
 				ble.s	.nobug1
@@ -103,8 +103,8 @@ PLR2_mouse_control
 
 				move.w	d1,ADDTOBOBBLE
 
-				move.w	PLR2s_sinval,d1
-				move.w	PLR2s_cosval,d2
+				move.w	Plr2_SnapSinVal_w,d1
+				move.w	Plr2_SnapCosVal_w,d2
 
 				move.w	d2,d4
 				move.w	d1,d5
@@ -118,12 +118,12 @@ PLR2_mouse_control
 
 				sub.l	d1,d6
 				sub.l	d2,d7
-				add.l	d6,PLR2s_xspdval
-				add.l	d7,PLR2s_zspdval
-				move.l	PLR2s_xspdval,d6
-				move.l	PLR2s_zspdval,d7
-				add.l	d6,PLR2s_xoff
-				add.l	d7,PLR2s_zoff
+				add.l	d6,Plr2_SnapXSpdVal_l
+				add.l	d7,Plr2_SnapZSpdVal_l
+				move.l	Plr2_SnapXSpdVal_l,d6
+				move.l	Plr2_SnapZSpdVal_l,d7
+				add.l	d6,Plr2_SnapXOff_l
+				add.l	d7,Plr2_SnapZOff_l
 
 				tst.b	PLR2_fire
 				beq.s	.firenotpressed
@@ -199,7 +199,7 @@ PLR2_alwayskeys
 				st		gunheldlast
 
 				moveq	#0,d0
-				move.b	PLR2_GunSelected,d0
+				move.b	Plr2_GunSelected_b,d0
 				move.l	#PLAYERTWOGUNS,a0
 
 .findnext
@@ -211,7 +211,7 @@ PLR2_alwayskeys
 				tst.w	(a0,d0.w*2)
 				beq.s	.findnext
 
-				move.b	d0,PLR2_GunSelected
+				move.b	d0,Plr2_GunSelected_b
 				bsr		SHOWPLR2GUNNAME
 
 				bra		.nonextweap
@@ -234,16 +234,16 @@ PLR2_alwayskeys
 				tst.b	(a5,d7.w)
 				beq.s	.notduck
 				clr.b	(a5,d7.w)
-				move.l	#playerheight,PLR2s_targheight
+				move.l	#playerheight,Plr2_SnapTargHeight_l
 				not.b	PLR2_Ducked
 				beq.s	.notduck
-				move.l	#playercrouched,PLR2s_targheight
+				move.l	#playercrouched,Plr2_SnapTargHeight_l
 .notduck:
 
-				move.l	PLR2_Roompt,a4
+				move.l	Plr2_RoomPtr_l,a4
 				move.l	ZoneT_Floor_l(a4),d0
 				sub.l	ZoneT_Roof_l(a4),d0
-				tst.b	PLR2_StoodInTop
+				tst.b	Plr2_StoodInTop_b
 				beq.s	.usebottom
 				move.l	ZoneT_UpperFloor_l(a4),d0
 				sub.l	ZoneT_UpperRoof_l(a4),d0
@@ -258,14 +258,14 @@ PLR2_alwayskeys
 				move.l	#playercrouched,PLR2s_SquishedHeight
 oktostand2:
 
-				move.l	PLR2s_targheight,d1
+				move.l	Plr2_SnapTargHeight_l,d1
 				move.l	PLR2s_SquishedHeight,d0
 				cmp.l	d0,d1
 				blt.s	.notsqu
 				move.l	d0,d1
 .notsqu:
 
-				move.l	PLR2s_height,d0
+				move.l	Plr2_SnapHeight_l,d0
 				cmp.l	d1,d0
 				beq.s	.noupordown
 				bgt.s	.crouch
@@ -274,7 +274,7 @@ oktostand2:
 .crouch:
 				sub.l	#1024,d0
 .noupordown:
-				move.l	d0,PLR2s_height
+				move.l	d0,Plr2_SnapHeight_l
 
 				tst.b	$27(a5)
 				beq.s	.notselkey
@@ -309,7 +309,7 @@ pickweap2
 				move.w	(a2)+,d0
 				and.b	(a4)+,d0
 				beq.s	notgotweap2
-				move.b	d2,PLR2_GunSelected
+				move.b	d2,Plr2_GunSelected_b
 				move.w	#0,EntT_Timer1_w+64(a3)
 
 ; move.l #TEMPSCROLL,SCROLLPOINTER
@@ -345,7 +345,7 @@ gogogogog:
 
 SHOWPLR2GUNNAME:
 				moveq	#0,d2
-				move.b	PLR2_GunSelected,d2
+				move.b	Plr2_GunSelected_b,d2
 
 				move.l	GLF_DatabasePtr_l,a4
 				add.l	#GLFT_GunNames_l,a4
@@ -469,8 +469,8 @@ PLR2_keyboard_control:
 				muls	#SCREENWIDTH,d0
 				move.l	d0,SBIGMIDDLEY
 
-				move.w	PLR2s_angpos,d0
-				move.w	PLR2s_angspd,d3
+				move.w	Plr2_SnapAngPos_w,d0
+				move.w	Plr2_SnapAngSpd_w,d3
 				move.w	#35,d1
 				move.w	#2,d2
 				move.w	#10,TURNSPD
@@ -549,7 +549,7 @@ noturnposs2:
 
 				add.w	d3,d0
 				add.w	d3,d0
-				move.w	d3,PLR2s_angspd
+				move.w	d3,Plr2_SnapAngSpd_w
 
 				move.b	tempslkey,d7
 				tst.b	(a5,d7.w)
@@ -571,14 +571,14 @@ noturnposs2:
 noslide2:
 
 				and.w	#8191,d0
-				move.w	d0,PLR2s_angpos
+				move.w	d0,Plr2_SnapAngPos_w
 
-				move.w	(a0,d0.w),PLR2s_sinval
+				move.w	(a0,d0.w),Plr2_SnapSinVal_w
 				adda.w	#2048,a0
-				move.w	(a0,d0.w),PLR2s_cosval
+				move.w	(a0,d0.w),Plr2_SnapCosVal_w
 
-				move.l	PLR2s_xspdval,d6
-				move.l	PLR2s_zspdval,d7
+				move.l	Plr2_SnapXSpdVal_l,d6
+				move.l	Plr2_SnapZSpdVal_l,d7
 
 				tst.b	SLOWDOWN
 				beq.s	.nofriction
@@ -626,29 +626,29 @@ noslide2:
 ; add.w d2,d1
 				move.w	d1,ADDTOBOBBLE
 
-				move.w	PLR2s_sinval,d1
+				move.w	Plr2_SnapSinVal_w,d1
 				muls	d3,d1
-				move.w	PLR2s_cosval,d2
+				move.w	Plr2_SnapCosVal_w,d2
 				muls	d3,d2
 
 				sub.l	d1,d6
 				sub.l	d2,d7
-				move.w	PLR2s_sinval,d1
+				move.w	Plr2_SnapSinVal_w,d1
 				muls	d4,d1
-				move.w	PLR2s_cosval,d2
+				move.w	Plr2_SnapCosVal_w,d2
 				muls	d4,d2
 				sub.l	d2,d6
 				add.l	d1,d7
 
 				tst.b	SLOWDOWN
 				beq.s	.nocontrolposs
-				add.l	d6,PLR2s_xspdval
-				add.l	d7,PLR2s_zspdval
+				add.l	d6,Plr2_SnapXSpdVal_l
+				add.l	d7,Plr2_SnapZSpdVal_l
 .nocontrolposs:
-				move.l	PLR2s_xspdval,d6
-				move.l	PLR2s_zspdval,d7
-				add.l	d6,PLR2s_xoff
-				add.l	d7,PLR2s_zoff
+				move.l	Plr2_SnapXSpdVal_l,d6
+				move.l	Plr2_SnapZSpdVal_l,d7
+				add.l	d6,Plr2_SnapXOff_l
+				add.l	d7,Plr2_SnapZOff_l
 
 				move.b	fire_key,d5
 				tst.b	PLR2_fire
@@ -695,17 +695,17 @@ PLR2_clumptime:	dc.w	0
 PLR2clump:
 
 				movem.l	d0-d7/a0-a6,-(a7)
-				move.l	PLR2_Roompt,a0
+				move.l	Plr2_RoomPtr_l,a0
 				move.w	ZoneT_FloorNoise_w(a0),d0
 
 				move.l	ZoneT_Water_l(a0),d1
 				cmp.l	ZoneT_Floor_l(a0),d1
 				bge.s	THERESNOWATER2
 
-				cmp.l	PLR2_yoff,d1
+				cmp.l	Plr2_YOff_l,d1
 				blt.s	THERESNOWATER2
 
-				tst.b	PLR2_StoodInTop
+				tst.b	Plr2_StoodInTop_b
 				bne.s	THERESNOWATER2
 
 				move.w	#6,d0
@@ -713,7 +713,7 @@ PLR2clump:
 
 THERESNOWATER2:
 
-				tst.b	PLR2_StoodInTop
+				tst.b	Plr2_StoodInTop_b
 				beq.s	.okinbot
 				move.w	ZoneT_UpperFloorNoise_w(a0),d0
 .okinbot:
@@ -732,7 +732,7 @@ THERESWATER2:
 				move.w	#80,Noisevol
 				move.w	#$fff8,IDNUM
 				clr.b	notifplaying
-				move.b	PLR2_Echo,SourceEcho
+				move.b	Plr2_Echo_b,SourceEcho
 				jsr		MakeSomeNoise
 
 nofootsound2:


### PR DESCRIPTION
Renaming of Player related globals to match the proposed style:
- Fixes a number of wrongly-sized entries.
- Removes a number of unused or write-only entries.
- Rearranges entries to improve data alignment.

Playtested several levels to ensure no new regressions.