### PR TITLE
Candidate fix for Issue 40 (Wall texture perspective).

### DIFF
--- a/ab3d2_source/chunky.s
+++ b/ab3d2_source/chunky.s
@@ -7,6 +7,10 @@
 				; d4 !=0 use doublewidth
 				; d5 !=0 use teleport effect
 
+				; HACK - This is a temporary fix until the root cause of the wall texture
+				; perspective issues are properly understood.
+FS_C2P_HEIGHT equ FS_HEIGHT-8
+
 Vid_ConvertC2P:
 				tst.b	d5
 				beq.s	.noteleffect
@@ -36,7 +40,7 @@ Vid_ConvertC2P:
 
 				move.w	#SCREENWIDTH,d0
 				move.w	Vid_LetterBoxMarginHeight_w,d3				; height of black border top/bottom
-				move.w	#232,d1
+				move.w	#FS_C2P_HEIGHT,d1
 				sub.w	d3,d1					; top letterbox
 				sub.w	d3,d1					; bottom letterbox: d1: number of lines
 				move.l	#(SCREENWIDTH/8)*256,d5
@@ -261,11 +265,11 @@ Vid_ConvertC2P:
 				; 0xABADCAFE - Changing FS_HEIGHT to 240 from 232 impacted the teleportation
 				; shimmer in fullscreen which seems coupled to the original size.
 
-FS_TELFX_HEIGHT equ FS_HEIGHT-8
 
-				move.l	#FS_TELFX_HEIGHT-1,d1	; height of area to convert
-				sub.w	d7,d1					; top letterbox
-				sub.w	d7,d1					; bottom letterbox: d1: number of lines
+
+				move.l	#FS_C2P_HEIGHT-1,d1	; height of area to convert
+				sub.w	d7,d1				; top letterbox
+				sub.w	d7,d1				; bottom letterbox: d1: number of lines
 				move.w	d1,HTC
 
 				move.w	#(SCREENWIDTH-FS_WIDTH),MODUL ; modulo chunky

--- a/ab3d2_source/chunky.s
+++ b/ab3d2_source/chunky.s
@@ -257,7 +257,13 @@ Vid_ConvertC2P:
 				move.w	#(FS_WIDTH/8)-1,WTC		; width in chipmem?
 
 				move.w	Vid_LetterBoxMarginHeight_w,d7
-				move.l	#FS_HEIGHT-1,d1			; height of area to convert
+
+				; 0xABADCAFE - Changing FS_HEIGHT to 240 from 232 impacted the teleportation
+				; shimmer in fullscreen which seems coupled to the original size.
+
+FS_TELFX_HEIGHT equ FS_HEIGHT-8
+
+				move.l	#FS_TELFX_HEIGHT-1,d1	; height of area to convert
 				sub.w	d7,d1					; top letterbox
 				sub.w	d7,d1					; bottom letterbox: d1: number of lines
 				move.w	d1,HTC

--- a/ab3d2_source/hires.s
+++ b/ab3d2_source/hires.s
@@ -28,7 +28,7 @@
 CD32VER					equ		0
 
 FS_WIDTH				equ		320
-FS_HEIGHT				equ		232
+FS_HEIGHT				equ		240;232
 SMALL_WIDTH				equ		192
 SMALL_HEIGHT			equ		160
 SCREENWIDTH				equ		320

--- a/ab3d2_source/newanims.s
+++ b/ab3d2_source/newanims.s
@@ -1392,9 +1392,9 @@ NOTMOVING:
 				move.w	d0,2(a1)
 				move.w	d3,d0
 
-				;muls	#256,d3
-				ext.l	d3		; Safety: Sign extend before shift
-				asl.l	#8,d3
+				muls	#256,d3
+				;ext.l	d3		; Safety: Sign extend before shift
+				;asl.l	#8,d3
 
 				move.l	Lvl_ZoneAddsPtr_l,a1
 				move.w	(a0)+,d5


### PR DESCRIPTION
Credit to Andy Loft.
- Fixes the perspective discrepancy between floors/ceilings and walls in fullscreen. 
- C2P height coupled to old height
- Reverts a possibly buggy optimisation that slipped through the previous PR.

Suggested as a temporary fix for the short term 