### PR TITLE
Performance tweaks

### DIFF
--- a/ab3d2_source/hiresgourwall.s
+++ b/ab3d2_source/hiresgourwall.s
@@ -45,22 +45,25 @@ sometodrawG:
 				; The iterations are bound by the next power-of-two number covering the whole width
 				; FIXME: this is another place where the maximum resolution is hardcoded into the
 				; size of itertabG
-				move.w	itertabG(pc,d1.w*4),d7	; how many iterations for this width; or is it a mask?
+
+				;move.w	itertabG(pc,d1.w*4),d7	; how many iterations for this width; or is it a mask?
+				;swap	d0
+				;move.w	itertabG+2(pc,d1.w*4),d6 ; shift for this width
+
+				; read both words from the iteration table in one go. Do a small bit of juggling
+				; of instruction order, may help on 060 (TBC)
+				move.l	draw_IterationTable_vw(pc,d1.w*4),d7
 				swap	d0
-				move.w	itertabG+2(pc,d1.w*4),d6 ; shift for this width
+				move.w	d7,d6
 				clr.w	d0						; leftx in high word
 				swap	d1
+				swap	d7
 				clr.w	d1						; width in high word
 				asr.l	d6,d1					; divide down by shift
 				move.l	d1,(a0)					; save
 
-				bra		pstitG
-
-itertabG:
-				incbin	"includes/iterfile"
-
 				; Reading input walls from a0 and writing calculated deltas back into a0
-pstitG:
+
 				moveq	#0,d1
 				move.w	4(a0),d1				; leftbm
 				moveq	#0,d2

--- a/ab3d2_source/hireswall.s
+++ b/ab3d2_source/hireswall.s
@@ -115,6 +115,10 @@ SCALE			MACRO
 * 16(a0)=leftbot
 * 18(a0)=rightbot
 
+; Just one copy of the iteration table. Should improve cache locality if nothing else.
+				align 4
+draw_IterationTable_vw:
+				incbin	"includes/iterfile" ; todo - move to data, change access via a3?
 
 Doleftend:
 				move.w	leftclip,d0
@@ -127,21 +131,22 @@ Doleftend:
 				rts
 
 sometodraw:
-				move.w	draw_IterationTable_vw(pc,d1.w*4),d7
+				;move.w	draw_IterationTable_vw(pc,d1.w*4),d7
+				;swap	d0
+				;move.w	draw_IterationTable_vw+2(pc,d1.w*4),d6
+
+				; read both words from the iteration table in one go. Do a small bit of juggling
+				; of instruction order, may help on 060 (TBC)
+				move.l	draw_IterationTable_vw(pc,d1.w*4),d7
 				swap	d0
-				move.w	draw_IterationTable_vw+2(pc,d1.w*4),d6
+				move.w	d7,d6
 				clr.w	d0
 				swap	d1
+				swap	d7
 				clr.w	d1
 				asr.l	d6,d1
 				move.l	d1,(a0)
 
-				bra		pstit
-
-draw_IterationTable_vw:
-				incbin	"includes/iterfile" ; todo - move to data, change access via a3?
-
-pstit:
 				moveq	#0,d1
 				move.w	4(a0),d1
 				moveq	#0,d2

--- a/ab3d2_source/newplayershoot.s
+++ b/ab3d2_source/newplayershoot.s
@@ -421,7 +421,7 @@ Plr2_Shot:
 
 .not_negative:
 				; 0xABADCAFE division pogrom
-				divs	#44,d2 ; Hitscanning doesnt work without this. Why 44?
+				;divs	#44,d2 ; Hitscanning doesnt work without this. Why 44?
 
 				; Approximate 1/44 as 93/4096
 				muls	#93,d2 ; todo - maybe needs to be muls.l


### PR DESCRIPTION
Updated wall drawing code to share the same iteration file include and to read the required word pair parameters from it using a single 32-bit read. The following instructions reorganised slightly in the probably vain hope it may be better for 060.