### PR TITLE
a 'hack' to ensure the DisplayMsgPort is empty when starting a game/l…

### DIFF
--- a/ab3d2_source/hires.s
+++ b/ab3d2_source/hires.s
@@ -28,6 +28,7 @@
 CD32VER					equ		0
 
 FS_HEIGHT_HACK			equ		1 ; 0xABADCAFE - Fullscreen height hack, set non-zero to enable
+DISPLAYMSGPORT_HACK		equ		1 ; AL - Level restart freeze hack, set non-zero to enable
 
 
 	IFNE	FS_HEIGHT_HACK
@@ -574,6 +575,15 @@ noclips:
 
 				; FIXME: reimplement level blurb
 ; move.l #Blurbfield,$dff080
+
+	IFNE	DISPLAYMSGPORT_HACK
+				;empty DisplayMsgPort and set ScreenBufferIndex to 0
+				;so the starting point is the same every time
+.clrMsgPort			move.l	DisplayMsgPort,a0
+				CALLEXEC GetMsg
+				tst.l	d0
+				bne.s	.clrMsgPort
+	ENDC
 
 				clr.w	ScreenBufferIndex
 

--- a/ab3d2_source/hires.s
+++ b/ab3d2_source/hires.s
@@ -29,6 +29,7 @@ CD32VER					equ		0
 
 FS_HEIGHT_HACK			equ		1 ; 0xABADCAFE - Fullscreen height hack, set non-zero to enable
 DISPLAYMSGPORT_HACK		equ		1 ; AL - Level restart freeze hack, set non-zero to enable
+SCREEN_TITLEBAR_HACK		equ		1 ; AL - Stop title bar interactions hack, set non-zero to enable
 
 
 	IFNE	FS_HEIGHT_HACK

--- a/ab3d2_source/screensetup.s
+++ b/ab3d2_source/screensetup.s
@@ -286,6 +286,11 @@ MainScreenTags	dc.l	SA_Width,320
 				dc.l	SA_BitMap,MainBitmap0
 				dc.l	SA_Type,CUSTOMSCREEN
 				dc.l	SA_Quiet,1
+				IFNE	SCREEN_TITLEBAR_HACK
+				dc.l	SA_ShowTitle,0
+				ELSE
+				dc.l	SA_ShowTitle,1
+				ENDC
 				dc.l	SA_AutoScroll,0
 				dc.l	SA_FullPalette,1
 				dc.l	SA_DisplayID,PAL_MONITOR_ID


### PR DESCRIPTION
…evel, which stops the game freezing on level restart