### PR TITLE
060 optimizations (guarded by OPT060)

### DIFF
--- a/ab3d2_source/hires.s
+++ b/ab3d2_source/hires.s
@@ -7310,6 +7310,37 @@ leftbright:		dc.l	0
 brightspd:		dc.l	0
 
 gouraudfloor:
+				ifd OPT060
+
+				moveq   #0,d0
+				move.w	leftbright,d0
+				move.w  brightspd,d4
+				move.l  d2,a2
+
+				and.l   d1,d5
+				move.l  d5,d6
+				lsr.l   #8,d6
+				move.l  d6,d2
+				lsr.l   #8,d6
+				move.b  d2,d6   ; d6 ready for first iteration
+.loop:
+				move.l  d0,d3           ; d3=00Cc
+				move.b  (a0,d6.l*4),d3  ; d3=00CT
+				add.w   d4,d0           ; c += dcdx
+				add.l   a2,d5           ; uv += duvdx
+				and.l   d1,d5           ; uv &= uvmask
+				move.l  d5,d6           ; d6=VvUu
+				lsr.l   #8,d6           ; d6=0VvU
+				move.l  d6,d2           ; d2=0VvU
+				lsr.l   #8,d6           ; d6=00Vv
+				move.b  d2,d6           ; d6=00VU
+				move.b  (a1,d3.l),(a3)+
+				subq.w  #1,d7
+				bne.b   .loop
+				rts
+
+				else ; OPT060
+
 				move.w	leftbright,d0
 				move.l	d1,d4
 				move.w	brightspd,d1
@@ -7421,6 +7452,7 @@ acrossscrngour:
 
 				rts
 
+				endc ; OPT060
 
 gouraudfloorDOUB:
 				move.w	leftbright,d0
@@ -7543,24 +7575,6 @@ acrossscrngourD:
 				addq	#4,a3
 
 ; dbra d7,backbeforegour
-				rts
-
-
-gotoacrossgour:
-
-				move.w	d4,d7
-				bne.s	.notdoneyet
-				rts
-.notdoneyet:
-
-				cmp.w	#32,d7
-				ble.s	.notoowide
-				move.w	#32,d7
-.notoowide
-				sub.w	d7,d4
-				addq	#4,a3
-
-				dbra	d7,acrossscrngour
 				rts
 
 

--- a/ab3d2_source/hireswall.s
+++ b/ab3d2_source/hireswall.s
@@ -1366,6 +1366,58 @@ nocliptop:
 
 ;wlcnt:			dc.w	0 ; unused
 
+				ifd OPT060
+
+drawwallS060_loop	macro
+val set \2
+.loop\<val>:
+				; grab packed texel
+				ifeq    \1-0
+				moveq   #%00011111,d1
+				and.b   1(a5,d4.w*2),d1
+				endc
+				ifeq    \1-1
+				move.w  (a5,d4.w*2),d1
+				lsr.w   #5,d1
+				and.w   #%00011111,d1
+				endc
+				ifeq    \1-2
+				moveq   #%01111100,d1
+				and.b   (a5,d4.w*2),d1
+				lsr.b   #2,d1
+				endc
+
+				; v step (fractional first, then integer part)
+				add.l   d3,d4
+				addx.w  d2,d4
+				and.w   d7,d4
+
+				; store through palette lookup (note: alternates between a2 and a4)
+				ifeq \2
+				move.b  (a2,d1.w*2),(a3)
+				else
+				move.b  (a4,d1.w*2),(a3)
+				endc
+
+				; dest += width
+				adda.w  d0,a3
+val set val^1
+				dbf     d6,.loop\<val>
+				rts
+				endm
+
+drawwallS060	macro
+				and.w   d7,d4   ; make sure offset is masked
+				drawwallS060_loop \1,0
+				drawwallS060_loop \1,1
+				endm
+
+drawwallPACK0:	drawwallS060 0
+drawwallPACK1:	drawwallS060 1
+drawwallPACK2:	drawwallS060 2
+
+				else ; OPT060
+
 				align 4
 drawwalldimPACK0:
 				and.w	d7,d4
@@ -1443,6 +1495,8 @@ drawwallPACK2:
 				addx.w	d2,d4
 				dbra	d6,drawwalldimPACK2
 				rts
+
+				endc ; OPT060
 
 usesimple:
 				mulu	d3,d4


### PR DESCRIPTION
68060 optimisations for wall and floor inner rendering loops

add -DOPT060 to the makefile AFLAGS to enable.