### PR TITLE
RTG Border/HUD fixes

### DIFF
--- a/ab3d2_source/bss/draw_bss.s
+++ b/ab3d2_source/bss/draw_bss.s
@@ -83,6 +83,20 @@ draw_Left_w:					ds.w	1
 draw_Right_w:					ds.w	1
 draw_DownStrip_w:				ds.w	1
 
+
+; Border Ammo/Energy
+_draw_DisplayEnergyCount_w::
+draw_DisplayEnergyCount_w:      ds.w	1
+
+_draw_DisplayAmmoCount_w::
+draw_DisplayAmmoCount_w:	    ds.w	1
+
+_draw_LastDisplayEnergyCount_w::
+draw_LastDisplayEnergyCount_w:	ds.w	1
+
+_draw_LastDisplayAmmoCount_w::
+draw_LastDisplayAmmoCount_w:	ds.w	1
+
 draw_WhichDoing_b:				ds.b	1
 draw_InUpperZone_b:				ds.b	1
 Draw_DoUpper_b:					ds.b	1

--- a/ab3d2_source/bss/player_bss.s
+++ b/ab3d2_source/bss/player_bss.s
@@ -67,6 +67,8 @@ Plr1_JetpackFuel_w:			ds.w	1
 Plr1_AmmoCounts_vw:			ds.w	20
 Plr1_Shield_w:				ds.w	1
 Plr1_Jetpack_w:				ds.w	1
+
+_Plr1_Weapons_vb::
 Plr1_Weapons_vb:			ds.w	10 ; todo - convert to bytes or bitfield
 
 Plr1_GunFrame_w:			ds.w	1
@@ -100,6 +102,7 @@ Plr1_Used_b:				ds.b	1
 Plr1_TmpClicked_b:			ds.b	1
 Plr1_TmpSpcTap_b:			ds.b	1
 
+_Plr1_TmpGunSelected_b::
 Plr1_TmpGunSelected_b:		ds.b	1
 Plr1_TmpFire_b:				ds.b	1
 
@@ -172,6 +175,8 @@ Plr2_JetpackFuel_w:			ds.w	1
 Plr2_AmmoCounts_vw:			ds.w	20
 Plr2_Shield_w:				ds.w	1
 Plr2_Jetpack_w:				ds.w	1
+
+_Plr2_Weapons_vb::
 Plr2_Weapons_vb:			ds.w	10 ; todo - convert to bytes or bitfield
 
 Plr2_GunFrame_w:			ds.w	1
@@ -205,6 +210,7 @@ Plr2_Used_b:				ds.b	1
 Plr2_TmpClicked_b:			ds.b	1
 Plr2_TmpSpcTap_b:			ds.b	1
 
+_Plr2_TmpGunSelected_b::
 Plr2_TmpGunSelected_b:		ds.b	1
 Plr2_TmpFire_b:				ds.b	1
 
@@ -238,6 +244,7 @@ Plr_AddToBobble_w:				ds.w	1
 ; Private
 plr_FallDamage_w:				ds.w	1 ; fall.s
 
+_Plr_MultiplayerType_b::
 Plr_MultiplayerType_b:			ds.b	1	; CHAR enum - m(aster), s(lave), n(either)
 Plr_Decelerate_b:				ds.b	1
 

--- a/ab3d2_source/c/draw.c
+++ b/ab3d2_source/c/draw.c
@@ -1,5 +1,4 @@
 #include "draw.h"
-#include "screen.h"
 #include "system.h"
 
 #include <SDI_compiler.h>
@@ -10,21 +9,20 @@
 #include <proto/exec.h>
 #include <string.h>  //memset
 
+/**
+ * TODO We do a lot of things here on the assumption that we are going to be using an RTG display, but that is a runtime
+ * determined fact. We should only allocate and convert chunky representations of planar assets if, and only if, we are
+ * on an RTG screen.
+ */
+
 #define RTG_LONG_ALIGNED
+
+#define MULTIPLAYER_SLAVE  ((BYTE)'s')
+#define MULTIPLAYER_MASTER ((BYTE)'m')
+
 
 #define VID_FAST_BUFFER_SIZE (SCREEN_WIDTH * SCREEN_HEIGHT + 4095)
 #define PLANESIZE (SCREEN_WIDTH / 8 * SCREEN_HEIGHT)
-
-/* These are the positions in the border for the ammo and health glyphs to be rendered */
-#define AMMO_COUNT_X_COORD 160
-#define AMMO_COUNT_Y_COORD (SCREEN_HEIGHT - 18)
-#define ENERGY_COUNT_X_COORD 272
-#define ENERGY_COUNT_Y_COORD (SCREEN_HEIGHT - 18)
-
-/* These define the size of the digits used in the ammo/energy display */
-#define BORDER_CHAR_WIDTH 8
-#define BORDER_CHAR_HEIGHT 7
-#define DISPLAY_COUNT_WIDTH (3 * BORDER_CHAR_WIDTH)
 
 /* These define limits for when the displayed count*/
 #define LOW_AMMO_COUNT_WARN_LIMIT 9
@@ -34,40 +32,75 @@
 extern void unLHA(REG(a0, void *dst), REG(d0, const void *src), REG(d1, ULONG length), REG(a1, void *workspace),
                   REG(a2, void *X));
 
+/* Externally declared buffers */
 extern ULONG Sys_Workspace_vl[];
 extern const UBYTE draw_BorderPacked_vb[];
 extern UBYTE draw_BorderChars_vb[];
-extern UWORD draw_DisplayEnergyCount_w;
-extern UWORD draw_DisplayAmmoCount_w;
-
 static UBYTE draw_Border[SCREEN_WIDTH * SCREEN_HEIGHT];
 
+/* Values used to track changes to the counters */
+extern UWORD draw_DisplayEnergyCount_w;
+extern UWORD draw_DisplayAmmoCount_w;
+extern UWORD draw_LastDisplayAmmoCount_w;
+extern UWORD draw_LastDisplayEnergyCount_w;
+extern BYTE  Plr_MultiplayerType_b;
+extern UBYTE Plr1_TmpGunSelected_b;
+extern UBYTE Plr2_TmpGunSelected_b;
+extern UWORD Plr1_Weapons_vb[DRAW_NUM_WEAPON_SLOTS];
+extern UWORD Plr2_Weapons_vb[DRAW_NUM_WEAPON_SLOTS];
+
+typedef PLANEPTR BitPlanes[8];
+
 /* Border digits when not low on ammo/health */
-static UBYTE draw_BorderDigitsGood[BORDER_CHAR_WIDTH * BORDER_CHAR_HEIGHT * 10];
+static UBYTE draw_BorderDigitsGood[DRAW_HUD_CHAR_W * DRAW_HUD_CHAR_H * 10];
 
 /* Border digits when low on ammo/health */
-static UBYTE draw_BorderDigitsWarn[BORDER_CHAR_WIDTH * BORDER_CHAR_HEIGHT * 10];
+static UBYTE draw_BorderDigitsWarn[DRAW_HUD_CHAR_W * DRAW_HUD_CHAR_H * 10];
 
-/* Small buffer for rendering the 3 digit counters into */
-static UBYTE draw_BorderDigitsBuffer[DISPLAY_COUNT_WIDTH * BORDER_CHAR_HEIGHT];
+/** Border digits for items not yet located */
+static UBYTE draw_BorderDigitsItem[DRAW_HUD_CHAR_SMALL_W * DRAW_HUD_CHAR_SMALL_H * 10];
+
+/** Border digits for items located */
+static UBYTE draw_BorderDigitsItemFound[DRAW_HUD_CHAR_SMALL_W * DRAW_HUD_CHAR_SMALL_H * 10];
+
+/** Border digits for item selected */
+static UBYTE draw_BorderDigitsItemSelected[DRAW_HUD_CHAR_SMALL_W * DRAW_HUD_CHAR_SMALL_H * 10];
+
+
+/* Small buffer for rendering digit displays into */
+static UBYTE draw_BorderDigitsBuffer[DRAW_HUD_CHAR_SMALL_H * DRAW_HUD_CHAR_SMALL_W * 10];
 
 static UBYTE *FastBufferAllocPtr;
 
-/* Values used to track changes to the counters */
-static UWORD draw_LastDisplayAmmoCount   = 0xFFFF;
-static UWORD draw_LastDisplayEnergyCount = 0xFFFF;
-
 static void draw_PlanarToChunky(UBYTE *chunky, const PLANEPTR *planes, ULONG numPixels);
 static void draw_ValueToDigits(UWORD value, UWORD digits[3]);
-static void draw_GenerateCounterDigits_RTG(UBYTE* chunky, const UBYTE *planar);
+static void draw_GenerateCounterDigits_RTG(UBYTE* chunky, const UBYTE *planar, UWORD height);
 static void draw_RenderCounterDigit_RTG(UBYTE *drawPtr, const UBYTE *glyphs, UWORD digit, UWORD span);
-static void draw_UpdateCounter_RTG(APTR bmBaseAdress, ULONG bmBytesPerRow, UWORD count, UWORD limit, UWORD xPos, UWORD yPos);
+static void draw_RenderItemDigit_RTG(UBYTE *drawPtr, const UBYTE *glyphs, UWORD digit, UWORD span);
+
+static void draw_UpdateCounter_RTG(
+    APTR bmBaseAddress,
+    ULONG bmBytesPerRow,
+    UWORD count,
+    UWORD limit,
+    UWORD xPos,
+    UWORD yPos
+);
+
+static void draw_UpdateItems_RTG(
+    APTR bmBaseAddress,
+    ULONG bmBytesPerRow,
+    const UWORD* itemSlots,
+    UWORD itemSelected,
+    UWORD xPos,
+    UWORD yPos
+);
 
 /**********************************************************************************************************************/
 
 BOOL Draw_Init()
 {
-    if (!(FastBufferAllocPtr = AllocVec(VID_FAST_BUFFER_SIZE, MEMF_ANY))) {
+    if (!(FastBufferAllocPtr = AllocVec(VID_FAST_BUFFER_SIZE, MEMF_FAST))) {
         goto fail;
     }
 
@@ -75,7 +108,7 @@ BOOL Draw_Init()
 
     unLHA(Vid_FastBufferPtr_l, draw_BorderPacked_vb, 0, Sys_Workspace_vl, NULL);
 
-    PLANEPTR planes[8];
+    BitPlanes planes;
 
     for (int p = 0; p < 8; ++p) {
         planes[p] = Vid_FastBufferPtr_l + PLANESIZE * p;
@@ -84,15 +117,38 @@ BOOL Draw_Init()
     // The image we have has a fixed size
     draw_PlanarToChunky(draw_Border, planes, SCREEN_WIDTH * SCREEN_HEIGHT);
 
-	draw_GenerateCounterDigits_RTG(
-		draw_BorderDigitsWarn,
-		draw_BorderChars_vb + 15 * BORDER_CHAR_WIDTH * 10
-	);
+    draw_GenerateCounterDigits_RTG(
+        draw_BorderDigitsWarn,
+        draw_BorderChars_vb + 15 * DRAW_HUD_CHAR_W * 10,
+        DRAW_HUD_CHAR_H
+    );
 
-	draw_GenerateCounterDigits_RTG(
-		draw_BorderDigitsGood,
-		draw_BorderChars_vb + 15 * BORDER_CHAR_WIDTH * 10 + BORDER_CHAR_HEIGHT*BORDER_CHAR_WIDTH * 10
-	);
+    draw_GenerateCounterDigits_RTG(
+        draw_BorderDigitsGood,
+        draw_BorderChars_vb + 15 * DRAW_HUD_CHAR_W * 10 + DRAW_HUD_CHAR_H*DRAW_HUD_CHAR_W * 10,
+        DRAW_HUD_CHAR_H
+    );
+
+    draw_GenerateCounterDigits_RTG(
+        draw_BorderDigitsItem,
+        draw_BorderChars_vb,
+        DRAW_HUD_CHAR_SMALL_H
+    );
+
+    draw_GenerateCounterDigits_RTG(
+        draw_BorderDigitsItemFound,
+        draw_BorderChars_vb + DRAW_HUD_CHAR_SMALL_H * 10 * DRAW_HUD_CHAR_SMALL_W,
+        DRAW_HUD_CHAR_SMALL_H
+    );
+
+    draw_GenerateCounterDigits_RTG(
+        draw_BorderDigitsItemSelected,
+        draw_BorderChars_vb + DRAW_HUD_CHAR_SMALL_H * 10 * DRAW_HUD_CHAR_SMALL_W * 2,
+        DRAW_HUD_CHAR_SMALL_H
+    );
+
+    draw_LastDisplayAmmoCount_w =
+    draw_LastDisplayEnergyCount_w = 0xFFFF;
 
     return TRUE;
 
@@ -120,14 +176,14 @@ void Draw_ResetGameDisplay()
         memset(Vid_FastBufferPtr_l, 0, SCREEN_WIDTH * SCREEN_HEIGHT);
 
         ULONG bmBytesPerRow;
-        APTR bmBaseAdress;
+        APTR bmBaseAddress;
 
         APTR bmHandle = LockBitMapTags(
             Vid_MainScreen_l->ViewPort.RasInfo->BitMap,
             LBMI_BYTESPERROW,
             (ULONG)&bmBytesPerRow,
             LBMI_BASEADDRESS,
-            (ULONG)&bmBaseAdress,
+            (ULONG)&bmBaseAddress,
             TAG_DONE
         );
         if (bmHandle) {
@@ -136,19 +192,19 @@ void Draw_ResetGameDisplay()
             src += (SCREEN_HEIGHT - height) * SCREEN_WIDTH;
 
             if (bmBytesPerRow == SCREEN_WIDTH) {
-                memcpy(bmBaseAdress, src, SCREEN_WIDTH * height);
+                memcpy(bmBaseAddress, src, SCREEN_WIDTH * height);
             } else {
                 for (WORD y = 0; y < height; ++y) {
-                    memcpy(bmBaseAdress, src, SCREEN_WIDTH);
-                    bmBaseAdress += bmBytesPerRow;
+                    memcpy(bmBaseAddress, src, SCREEN_WIDTH);
+                    bmBaseAddress += bmBytesPerRow;
                     src += SCREEN_WIDTH;
                 }
             }
 
             /* Retrigger the counters */
-            draw_LastDisplayAmmoCount   = 0xFFFF;
-            draw_LastDisplayEnergyCount = 0xFFFF;
-            Draw_UpdateBorder_RTG(bmBaseAdress, bmBytesPerRow);
+            draw_LastDisplayAmmoCount_w   =
+            draw_LastDisplayEnergyCount_w = 0xFFFF;
+            Draw_UpdateBorder_RTG(bmBaseAddress, bmBytesPerRow);
 
             UnLockBitMap(bmHandle);
         }
@@ -178,33 +234,52 @@ void Draw_BorderEnergyBar()
  * Called during Vid_Present on the RTG codepath to update the border within the main bitmap lock. Also called when
  * resizing the display.
  */
-void Draw_UpdateBorder_RTG(APTR bmBaseAdress, ULONG bmBytesPerRow)
+void Draw_UpdateBorder_RTG(APTR bmBaseAddress, ULONG bmBytesPerRow)
 {
-    /* TODO weapon slots */
+    const UWORD* itemSlots;
+    UWORD itemSelected;
+
+    if (Plr_MultiplayerType_b == MULTIPLAYER_SLAVE) {
+        itemSlots    = Plr2_Weapons_vb;
+        itemSelected = Plr2_TmpGunSelected_b;
+    }
+    else {
+        itemSlots    = Plr1_Weapons_vb;
+        itemSelected = Plr1_TmpGunSelected_b;
+    }
+
+    draw_UpdateItems_RTG(
+        bmBaseAddress,
+        bmBytesPerRow,
+        itemSlots,
+        itemSelected,
+        DRAW_HUD_ITEM_SLOTS_X,
+        DRAW_HUD_ITEM_SLOTS_Y
+    );
 
     /* Ammunition */
-    if (draw_LastDisplayAmmoCount != draw_DisplayAmmoCount_w) {
-        draw_LastDisplayAmmoCount = draw_DisplayAmmoCount_w;
+    if (draw_LastDisplayAmmoCount_w != draw_DisplayAmmoCount_w) {
+        draw_LastDisplayAmmoCount_w = draw_DisplayAmmoCount_w;
         draw_UpdateCounter_RTG(
-            bmBaseAdress,
+            bmBaseAddress,
             bmBytesPerRow,
             draw_DisplayAmmoCount_w,
             LOW_AMMO_COUNT_WARN_LIMIT,
-            AMMO_COUNT_X_COORD,
-            AMMO_COUNT_Y_COORD
+            DRAW_HUD_AMMO_COUNT_X,
+            DRAW_HUD_AMMO_COUNT_Y
         );
     }
 
     /* Energy */
-    if (draw_LastDisplayEnergyCount != draw_DisplayEnergyCount_w) {
-        draw_LastDisplayEnergyCount = draw_DisplayEnergyCount_w;
+    if (draw_LastDisplayEnergyCount_w != draw_DisplayEnergyCount_w) {
+        draw_LastDisplayEnergyCount_w = draw_DisplayEnergyCount_w;
         draw_UpdateCounter_RTG(
-            bmBaseAdress,
+            bmBaseAddress,
             bmBytesPerRow,
             draw_DisplayEnergyCount_w,
             LOW_ENERGY_COUNT_WARN_LIMIT,
-            ENERGY_COUNT_X_COORD,
-            ENERGY_COUNT_Y_COORD
+            DRAW_HUD_ENERGY_COUNT_X,
+            DRAW_HUD_ENERGY_COUNT_Y
         );
     }
 }
@@ -214,8 +289,10 @@ void Draw_UpdateBorder_RTG(APTR bmBaseAdress, ULONG bmBytesPerRow)
  */
 static void draw_PlanarToChunky(UBYTE *chunkyPtr, PLANEPTR const *planePtrs, ULONG numPixels)
 {
-    PLANEPTR pptr[8];
-    memcpy(pptr, planePtrs, sizeof(pptr));
+    BitPlanes pptr;
+    for (BYTE p = 0; p < 8; ++p) {
+        pptr[p] = planePtrs[p];
+    }
 
     for (ULONG x = 0; x < numPixels / 8; ++x) {
         for (BYTE p = 0; p < 8; ++p) {
@@ -237,8 +314,8 @@ static void draw_PlanarToChunky(UBYTE *chunkyPtr, PLANEPTR const *planePtrs, ULO
 /**
  * Converts the border digits used for ammo/health from their initial planar representation to a chunky one
  */
-static void draw_GenerateCounterDigits_RTG(UBYTE* chunkyPtr, const UBYTE *planarBasePtr) {
-    PLANEPTR planes[8];
+static void draw_GenerateCounterDigits_RTG(UBYTE* chunkyPtr, const UBYTE *planarBasePtr, UWORD height) {
+    BitPlanes planes;
     const UBYTE *base_digit = planarBasePtr;
     UBYTE *out_digit  = chunkyPtr;
     for (int d = 0; d < 10; ++d) {
@@ -247,12 +324,12 @@ static void draw_GenerateCounterDigits_RTG(UBYTE* chunkyPtr, const UBYTE *planar
             planes[p] = (PLANEPTR)(digit + p * 10);
         }
 
-        for (int y = 0; y <  BORDER_CHAR_HEIGHT; ++y) {
-            draw_PlanarToChunky(out_digit, planes, BORDER_CHAR_WIDTH);
+        for (UWORD y = 0; y <  height; ++y) {
+            draw_PlanarToChunky(out_digit, planes, DRAW_HUD_CHAR_W);
             for (int p = 0; p < 8; ++p) {
-                planes[p] += BORDER_CHAR_WIDTH * 10;
+                planes[p] += DRAW_HUD_CHAR_W * 10;
             }
-            out_digit += BORDER_CHAR_WIDTH;
+            out_digit += DRAW_HUD_CHAR_W;
         }
     }
 }
@@ -260,10 +337,9 @@ static void draw_GenerateCounterDigits_RTG(UBYTE* chunkyPtr, const UBYTE *planar
 /**
  * Render a counter (3-digit) into
  */
-static void draw_UpdateCounter_RTG(APTR bmBaseAdress, ULONG bmBytesPerRow, UWORD count, UWORD limit, UWORD xPos, UWORD yPos)
+static void draw_UpdateCounter_RTG(APTR bmBaseAddress, ULONG bmBytesPerRow, UWORD count, UWORD limit, UWORD xPos, UWORD yPos)
 {
     UWORD digits[3];
-
     draw_ValueToDigits(count, digits);
 
     const UBYTE *glyphPtr = count > limit ?
@@ -272,49 +348,103 @@ static void draw_UpdateCounter_RTG(APTR bmBaseAdress, ULONG bmBytesPerRow, UWORD
 
     /* Render the digits into the mini buffer */
     UBYTE* bufferPtr = draw_BorderDigitsBuffer;
-    for (int i = 0; i < 3; ++i, bufferPtr += BORDER_CHAR_WIDTH) {
-        draw_RenderCounterDigit_RTG(bufferPtr, glyphPtr, digits[i], DISPLAY_COUNT_WIDTH);
+    for (int i = 0; i < 3; ++i, bufferPtr += DRAW_HUD_CHAR_W) {
+        draw_RenderCounterDigit_RTG(bufferPtr, glyphPtr, digits[i], DRAW_COUNT_W);
     }
 
     /* Copy the mini buffer to the bitmap */
-    UBYTE* drawPtr = ((UBYTE*)bmBaseAdress) + xPos + yPos * bmBytesPerRow;
+    UBYTE* drawPtr = ((UBYTE*)bmBaseAddress) + xPos + yPos * bmBytesPerRow;
 
     bufferPtr = draw_BorderDigitsBuffer;
-    for (int i = 0; i < BORDER_CHAR_HEIGHT; ++i, drawPtr += bmBytesPerRow, bufferPtr += DISPLAY_COUNT_WIDTH) {
+    for (int i = 0; i < DRAW_HUD_CHAR_H; ++i, drawPtr += bmBytesPerRow, bufferPtr += DRAW_COUNT_W) {
 
 #ifdef RTG_LONG_ALIGNED
-        CopyMemQuick(bufferPtr, drawPtr, DISPLAY_COUNT_WIDTH);
+        CopyMemQuick(bufferPtr, drawPtr, DRAW_COUNT_W);
 #else
-        memcpy(drawPtr, bufferPtr, DISPLAY_COUNT_WIDTH);
+        memcpy(drawPtr, bufferPtr, DRAW_COUNT_W);
 #endif
     }
 }
 
-/*
+static void draw_UpdateItems_RTG(APTR bmBaseAddress, ULONG bmBytesPerRow, const UWORD* itemSlots, UWORD itemSelected, UWORD xPos, UWORD yPos) {
+    UBYTE* drawPtr = ((UBYTE*)bmBaseAddress) + xPos + yPos * bmBytesPerRow;
+
+    /* Render into the minibuffer */
+    UBYTE *bufferPtr = draw_BorderDigitsBuffer;
+    for (UBYTE i=0; i < DRAW_NUM_WEAPON_SLOTS; ++i, bufferPtr += DRAW_HUD_CHAR_SMALL_W) {
+        const UBYTE *glyphPtr = itemSelected == i ?
+            draw_BorderDigitsItemSelected :
+            itemSlots[i] ?
+                draw_BorderDigitsItemFound :
+                draw_BorderDigitsItem;
+        draw_RenderItemDigit_RTG(bufferPtr, glyphPtr, i, DRAW_HUD_CHAR_SMALL_W*10);
+    }
+
+    /* Copy the mini buffer to the bitmap */
+    bufferPtr = draw_BorderDigitsBuffer;
+    for (int i = 0; i < DRAW_HUD_CHAR_SMALL_H; ++i, drawPtr += bmBytesPerRow, bufferPtr += DRAW_HUD_CHAR_SMALL_W*10) {
+
+#ifdef RTG_LONG_ALIGNED
+        CopyMemQuick(bufferPtr, drawPtr, DRAW_HUD_CHAR_SMALL_W*10);
+#else
+        memcpy(drawPtr, bufferPtr, DRAW_HUD_CHAR_SMALL_W*10);
+#endif
+    }
+
+}
+
+/**
  * Render a counter single digit
  */
 static void draw_RenderCounterDigit_RTG(UBYTE *drawPtr, const UBYTE *glyphPtr, UWORD digit, UWORD span) {
 
 #ifdef RTG_LONG_ALIGNED
-    const ULONG *digitPtr = (ULONG*)&glyphPtr[digit * BORDER_CHAR_WIDTH * BORDER_CHAR_HEIGHT];
+    const ULONG *digitPtr = (ULONG*)&glyphPtr[digit * DRAW_HUD_CHAR_W * DRAW_HUD_CHAR_H];
     ULONG *drawPtr32 = (ULONG*)drawPtr;
     span >>= 2;
-    for (int y = 0; y < BORDER_CHAR_HEIGHT; ++y) {
-        for (int x = 0; x < BORDER_CHAR_WIDTH/sizeof(ULONG); ++x) {
+    for (int y = 0; y < DRAW_HUD_CHAR_H; ++y) {
+        for (int x = 0; x < DRAW_HUD_CHAR_W/sizeof(ULONG); ++x) {
             drawPtr32[x] = *digitPtr++;
         }
         drawPtr32 += span;
     }
 #else
-    const UBYTE *digitPtr = &glyphPtr[digit * BORDER_CHAR_WIDTH * BORDER_CHAR_HEIGHT];
-    for (int y = 0; y < BORDER_CHAR_HEIGHT; ++y) {
-        for (int x = 0; x < BORDER_CHAR_WIDTH; ++x) {
+    const UBYTE *digitPtr = &glyphPtr[digit * DRAW_HUD_CHAR_W * DRAW_HUD_CHAR_H];
+    for (int y = 0; y < DRAW_HUD_CHAR_H; ++y) {
+        for (int x = 0; x < DRAW_HUD_CHAR_W; ++x) {
             drawPtr[x] = *digitPtr++;
         }
         drawPtr += span;
     }
 #endif
 }
+
+/**
+ * Render a counter single digit
+ */
+static void draw_RenderItemDigit_RTG(UBYTE *drawPtr, const UBYTE *glyphPtr, UWORD digit, UWORD span) {
+
+#ifdef RTG_LONG_ALIGNED
+    const ULONG *digitPtr = (ULONG*)&glyphPtr[digit * DRAW_HUD_CHAR_SMALL_W * DRAW_HUD_CHAR_SMALL_H];
+    ULONG *drawPtr32 = (ULONG*)drawPtr;
+    span >>= 2;
+    for (int y = 0; y < DRAW_HUD_CHAR_SMALL_H; ++y) {
+        for (int x = 0; x < DRAW_HUD_CHAR_SMALL_W/sizeof(ULONG); ++x) {
+            drawPtr32[x] = *digitPtr++;
+        }
+        drawPtr32 += span;
+    }
+#else
+    const UBYTE *digitPtr = &glyphPtr[digit * DRAW_HUD_CHAR_SMALL_W * DRAW_HUD_CHAR_SMALL_H];
+    for (int y = 0; y < DRAW_HUD_CHAR_SMALL_H; ++y) {
+        for (int x = 0; x < DRAW_HUD_CHAR_SMALL_W; ++x) {
+            drawPtr[x] = *digitPtr++;
+        }
+        drawPtr += span;
+    }
+#endif
+}
+
 
 static void draw_ValueToDigits(UWORD value, UWORD digits[3]) {
     if (value > DISPLAY_COUNT_LIMIT) {

--- a/ab3d2_source/c/draw.c
+++ b/ab3d2_source/c/draw.c
@@ -10,18 +10,26 @@
 #include <proto/exec.h>
 #include <string.h>  //memset
 
+#define RTG_LONG_ALIGNED
+
 #define VID_FAST_BUFFER_SIZE (SCREEN_WIDTH * SCREEN_HEIGHT + 4095)
 #define PLANESIZE (SCREEN_WIDTH / 8 * SCREEN_HEIGHT)
 
-#define AMMO_COUNT_X_COORD = 160
-#define AMMO_COUNT_Y_COORD = (SCREEN_HEIGHT - 18);
-
-#define ENERGY_COUNT_X_COORD = 160
-#define ENERGY_COUNT_Y_COORD = (SCREEN_HEIGHT - 18);
+/* These are the positions in the border for the ammo and health glyphs to be rendered */
+#define AMMO_COUNT_X_COORD 160
+#define AMMO_COUNT_Y_COORD (SCREEN_HEIGHT - 18)
+#define ENERGY_COUNT_X_COORD 272
+#define ENERGY_COUNT_Y_COORD (SCREEN_HEIGHT - 18)
 
 /* These define the size of the digits used in the ammo/energy display */
 #define BORDER_CHAR_WIDTH 8
 #define BORDER_CHAR_HEIGHT 7
+#define DISPLAY_COUNT_WIDTH (3 * BORDER_CHAR_WIDTH)
+
+/* These define limits for when the displayed count*/
+#define LOW_AMMO_COUNT_WARN_LIMIT 9
+#define LOW_ENERGY_COUNT_WARN_LIMIT 9
+#define DISPLAY_COUNT_LIMIT 999
 
 extern void unLHA(REG(a0, void *dst), REG(d0, const void *src), REG(d1, ULONG length), REG(a1, void *workspace),
                   REG(a2, void *X));
@@ -40,13 +48,20 @@ static UBYTE draw_BorderDigitsGood[BORDER_CHAR_WIDTH * BORDER_CHAR_HEIGHT * 10];
 /* Border digits when low on ammo/health */
 static UBYTE draw_BorderDigitsWarn[BORDER_CHAR_WIDTH * BORDER_CHAR_HEIGHT * 10];
 
+/* Small buffer for rendering the 3 digit counters into */
+static UBYTE draw_BorderDigitsBuffer[DISPLAY_COUNT_WIDTH * BORDER_CHAR_HEIGHT];
+
 static UBYTE *FastBufferAllocPtr;
 
+/* Values used to track changes to the counters */
+static UWORD draw_LastDisplayAmmoCount   = 0xFFFF;
+static UWORD draw_LastDisplayEnergyCount = 0xFFFF;
 
-static void draw_ConvertLargeBorderDigits(UBYTE* chunky, const UBYTE *planar);
 static void draw_PlanarToChunky(UBYTE *chunky, const PLANEPTR *planes, ULONG numPixels);
 static void draw_ValueToDigits(UWORD value, UWORD digits[3]);
-static void draw_LargeBorderDigitRTG(UBYTE* drawPtr, const UBYTE *glyphs, ULONG digit);
+static void draw_GenerateCounterDigits_RTG(UBYTE* chunky, const UBYTE *planar);
+static void draw_RenderCounterDigit_RTG(UBYTE *drawPtr, const UBYTE *glyphs, UWORD digit, UWORD span);
+static void draw_UpdateCounter_RTG(APTR bmBaseAdress, ULONG bmBytesPerRow, UWORD count, UWORD limit, UWORD xPos, UWORD yPos);
 
 /**********************************************************************************************************************/
 
@@ -69,12 +84,12 @@ BOOL Draw_Init()
     // The image we have has a fixed size
     draw_PlanarToChunky(draw_Border, planes, SCREEN_WIDTH * SCREEN_HEIGHT);
 
-	draw_ConvertLargeBorderDigits(
+	draw_GenerateCounterDigits_RTG(
 		draw_BorderDigitsWarn,
 		draw_BorderChars_vb + 15 * BORDER_CHAR_WIDTH * 10
 	);
 
-	draw_ConvertLargeBorderDigits(
+	draw_GenerateCounterDigits_RTG(
 		draw_BorderDigitsGood,
 		draw_BorderChars_vb + 15 * BORDER_CHAR_WIDTH * 10 + BORDER_CHAR_HEIGHT*BORDER_CHAR_WIDTH * 10
 	);
@@ -108,13 +123,13 @@ void Draw_ResetGameDisplay()
         APTR bmBaseAdress;
 
         APTR bmHandle = LockBitMapTags(
-			Vid_MainScreen_l->ViewPort.RasInfo->BitMap,
-			LBMI_BYTESPERROW,
-			(ULONG)&bmBytesPerRow,
-			LBMI_BASEADDRESS,
-			(ULONG)&bmBaseAdress,
-			TAG_DONE
-		);
+            Vid_MainScreen_l->ViewPort.RasInfo->BitMap,
+            LBMI_BYTESPERROW,
+            (ULONG)&bmBytesPerRow,
+            LBMI_BASEADDRESS,
+            (ULONG)&bmBaseAdress,
+            TAG_DONE
+        );
         if (bmHandle) {
             const UBYTE *src = draw_Border;
             WORD height = Vid_ScreenHeight < SCREEN_HEIGHT ? Vid_ScreenHeight : SCREEN_HEIGHT;
@@ -129,10 +144,17 @@ void Draw_ResetGameDisplay()
                     src += SCREEN_WIDTH;
                 }
             }
+
+            /* Retrigger the counters */
+            draw_LastDisplayAmmoCount   = 0xFFFF;
+            draw_LastDisplayEnergyCount = 0xFFFF;
+            Draw_UpdateBorder_RTG(bmBaseAdress, bmBytesPerRow);
+
             UnLockBitMap(bmHandle);
         }
     }
 }
+
 
 void Draw_LineOfText(REG(a0, const char *ptr), REG(a1, APTR screenPointer), REG(d0,  ULONG xxxx))
 {
@@ -141,37 +163,7 @@ void Draw_LineOfText(REG(a0, const char *ptr), REG(a1, APTR screenPointer), REG(
 
 void Draw_BorderAmmoBar()
 {
-    if (!Vid_isRTG) {
-		return;
-	}
-	LOCAL_CYBERGFX();
 
-	ULONG bmBytesPerRow;
-	APTR bmBaseAdress;
-
-	APTR bmHandle = LockBitMapTags(
-		Vid_MainScreen_l->ViewPort.RasInfo->BitMap,
-		LBMI_BYTESPERROW,
-		(ULONG)&bmBytesPerRow,
-		LBMI_BASEADDRESS,
-		(ULONG)&bmBaseAdress,
-		TAG_DONE
-	);
-	if (bmHandle) {
-		UWORD digits[3];
-
-		draw_ValueToDigits(draw_DisplayAmmoCount_w, digits);
-		const UBYTE *glyphs = draw_DisplayAmmoCount_w > 9 ? draw_BorderDigitsGood : draw_BorderDigitsWarn;
-
-		ULONG offset = AMMO_COUNT_X_COORD + AMMO_COUNT_Y_COORD * SCREEN_WIDTH;
-
-		UBYTE *drawPtr = (UBYTE*)bmBaseAdress;
-
-		for (int i=0; i < 3; ++i, offset += 8) {
-			draw_LargeBorderDigitRTG(drawPtr + offset, glyphs, digits[i]);
-		}
-		UnLockBitMap(bmHandle);
-	}
 }
 
 
@@ -182,22 +174,60 @@ void Draw_BorderEnergyBar()
 
 /**********************************************************************************************************************/
 
-static void draw_PlanarToChunky(UBYTE *chunky, PLANEPTR const *planes, ULONG numPixels)
+/**
+ * Called during Vid_Present on the RTG codepath to update the border within the main bitmap lock. Also called when
+ * resizing the display.
+ */
+void Draw_UpdateBorder_RTG(APTR bmBaseAdress, ULONG bmBytesPerRow)
+{
+    /* TODO weapon slots */
+
+    /* Ammunition */
+    if (draw_LastDisplayAmmoCount != draw_DisplayAmmoCount_w) {
+        draw_LastDisplayAmmoCount = draw_DisplayAmmoCount_w;
+        draw_UpdateCounter_RTG(
+            bmBaseAdress,
+            bmBytesPerRow,
+            draw_DisplayAmmoCount_w,
+            LOW_AMMO_COUNT_WARN_LIMIT,
+            AMMO_COUNT_X_COORD,
+            AMMO_COUNT_Y_COORD
+        );
+    }
+
+    /* Energy */
+    if (draw_LastDisplayEnergyCount != draw_DisplayEnergyCount_w) {
+        draw_LastDisplayEnergyCount = draw_DisplayEnergyCount_w;
+        draw_UpdateCounter_RTG(
+            bmBaseAdress,
+            bmBytesPerRow,
+            draw_DisplayEnergyCount_w,
+            LOW_ENERGY_COUNT_WARN_LIMIT,
+            ENERGY_COUNT_X_COORD,
+            ENERGY_COUNT_Y_COORD
+        );
+    }
+}
+
+/**
+ * Convert planar assets to chunky
+ */
+static void draw_PlanarToChunky(UBYTE *chunkyPtr, PLANEPTR const *planePtrs, ULONG numPixels)
 {
     PLANEPTR pptr[8];
-    memcpy(pptr, planes, sizeof(pptr));
+    memcpy(pptr, planePtrs, sizeof(pptr));
 
     for (ULONG x = 0; x < numPixels / 8; ++x) {
         for (BYTE p = 0; p < 8; ++p) {
-            chunky[p] = 0;
+            chunkyPtr[p] = 0;
             UBYTE bit = 1 << (7 - p);
             for (BYTE b = 0; b < 8; ++b) {
                 if (*pptr[b] & bit) {
-                    chunky[p] |= 1 << b;
+                    chunkyPtr[p] |= 1 << b;
                 }
             }
         }
-        chunky += 8;
+        chunkyPtr += 8;
         for (BYTE p = 0; p < 8; ++p) {
             pptr[p]++;
         }
@@ -207,43 +237,91 @@ static void draw_PlanarToChunky(UBYTE *chunky, PLANEPTR const *planes, ULONG num
 /**
  * Converts the border digits used for ammo/health from their initial planar representation to a chunky one
  */
-static void draw_ConvertLargeBorderDigits(UBYTE* chunky_output, const UBYTE *planar_input) {
-
+static void draw_GenerateCounterDigits_RTG(UBYTE* chunkyPtr, const UBYTE *planarBasePtr) {
     PLANEPTR planes[8];
-
-	const UBYTE *base_digit = planar_input;
-	UBYTE *out_digit  = chunky_output;
+    const UBYTE *base_digit = planarBasePtr;
+    UBYTE *out_digit  = chunkyPtr;
     for (int d = 0; d < 10; ++d) {
         const UBYTE *digit = base_digit + d;
-		for (int p = 0; p < 8; ++p) {
-			planes[p] = (PLANEPTR)(digit + p * 10);
-		}
+        for (int p = 0; p < 8; ++p) {
+            planes[p] = (PLANEPTR)(digit + p * 10);
+        }
 
-		for (int y = 0; y <  BORDER_CHAR_HEIGHT; ++y) {
-			draw_PlanarToChunky(out_digit, planes, BORDER_CHAR_WIDTH);
-			for (int p = 0; p < 8; ++p) {
-				planes[p] += BORDER_CHAR_WIDTH * 10;
-			}
-			out_digit += BORDER_CHAR_WIDTH;
-		}
+        for (int y = 0; y <  BORDER_CHAR_HEIGHT; ++y) {
+            draw_PlanarToChunky(out_digit, planes, BORDER_CHAR_WIDTH);
+            for (int p = 0; p < 8; ++p) {
+                planes[p] += BORDER_CHAR_WIDTH * 10;
+            }
+            out_digit += BORDER_CHAR_WIDTH;
+        }
     }
 }
 
-static void draw_LargeBorderDigitRTG(UBYTE* drawPtr, const UBYTE *glyphs, ULONG digit) {
-	const UBYTE *digitPtr = &glyphs[digit * BORDER_CHAR_WIDTH * BORDER_CHAR_HEIGHT];
-	for (int y = 0; y < BORDER_CHAR_HEIGHT; ++y) {
-	    for (int x=0; x < BORDER_CHAR_WIDTH; ++x) {
-		    drawPtr[x] = *digitPtr++;
-		}
-		drawPtr += SCREEN_WIDTH;
-	}
+/**
+ * Render a counter (3-digit) into
+ */
+static void draw_UpdateCounter_RTG(APTR bmBaseAdress, ULONG bmBytesPerRow, UWORD count, UWORD limit, UWORD xPos, UWORD yPos)
+{
+    UWORD digits[3];
+
+    draw_ValueToDigits(count, digits);
+
+    const UBYTE *glyphPtr = count > limit ?
+        draw_BorderDigitsGood :
+        draw_BorderDigitsWarn;
+
+    /* Render the digits into the mini buffer */
+    UBYTE* bufferPtr = draw_BorderDigitsBuffer;
+    for (int i = 0; i < 3; ++i, bufferPtr += BORDER_CHAR_WIDTH) {
+        draw_RenderCounterDigit_RTG(bufferPtr, glyphPtr, digits[i], DISPLAY_COUNT_WIDTH);
+    }
+
+    /* Copy the mini buffer to the bitmap */
+    UBYTE* drawPtr = ((UBYTE*)bmBaseAdress) + xPos + yPos * bmBytesPerRow;
+
+    bufferPtr = draw_BorderDigitsBuffer;
+    for (int i = 0; i < BORDER_CHAR_HEIGHT; ++i, drawPtr += bmBytesPerRow, bufferPtr += DISPLAY_COUNT_WIDTH) {
+
+#ifdef RTG_LONG_ALIGNED
+        CopyMemQuick(bufferPtr, drawPtr, DISPLAY_COUNT_WIDTH);
+#else
+        memcpy(drawPtr, bufferPtr, DISPLAY_COUNT_WIDTH);
+#endif
+    }
+}
+
+/*
+ * Render a counter single digit
+ */
+static void draw_RenderCounterDigit_RTG(UBYTE *drawPtr, const UBYTE *glyphPtr, UWORD digit, UWORD span) {
+
+#ifdef RTG_LONG_ALIGNED
+    const ULONG *digitPtr = (ULONG*)&glyphPtr[digit * BORDER_CHAR_WIDTH * BORDER_CHAR_HEIGHT];
+    ULONG *drawPtr32 = (ULONG*)drawPtr;
+    span >>= 2;
+    for (int y = 0; y < BORDER_CHAR_HEIGHT; ++y) {
+        for (int x = 0; x < BORDER_CHAR_WIDTH/sizeof(ULONG); ++x) {
+            drawPtr32[x] = *digitPtr++;
+        }
+        drawPtr32 += span;
+    }
+#else
+    const UBYTE *digitPtr = &glyphPtr[digit * BORDER_CHAR_WIDTH * BORDER_CHAR_HEIGHT];
+    for (int y = 0; y < BORDER_CHAR_HEIGHT; ++y) {
+        for (int x = 0; x < BORDER_CHAR_WIDTH; ++x) {
+            drawPtr[x] = *digitPtr++;
+        }
+        drawPtr += span;
+    }
+#endif
 }
 
 static void draw_ValueToDigits(UWORD value, UWORD digits[3]) {
-	if (value > 999) {
-		value = 999;
-	}
-	digits[2] = value % 10; value /= 10;
-	digits[1] = value % 10; value /= 10;
-	digits[0] = value;
+    if (value > DISPLAY_COUNT_LIMIT) {
+        value = DISPLAY_COUNT_LIMIT;
+    }
+    // Simple, ugly, decimation.
+    digits[2] = value % 10; value /= 10;
+    digits[1] = value % 10; value /= 10;
+    digits[0] = value;
 }

--- a/ab3d2_source/c/draw.c
+++ b/ab3d2_source/c/draw.c
@@ -106,7 +106,7 @@ static __inline void draw_ResetHUDCounters(void)
  */
 BOOL Draw_Init()
 {
-    if (!(FastBufferAllocPtr = AllocVec(VID_FAST_BUFFER_SIZE, MEMF_FAST))) {
+    if (!(FastBufferAllocPtr = AllocVec(VID_FAST_BUFFER_SIZE, MEMF_ANY))) {
         goto fail;
     }
 

--- a/ab3d2_source/c/draw.c
+++ b/ab3d2_source/c/draw.c
@@ -13,16 +13,42 @@
 #define VID_FAST_BUFFER_SIZE (SCREEN_WIDTH * SCREEN_HEIGHT + 4095)
 #define PLANESIZE (SCREEN_WIDTH / 8 * SCREEN_HEIGHT)
 
+#define AMMO_COUNT_X_COORD = 160
+#define AMMO_COUNT_Y_COORD = (SCREEN_HEIGHT - 18);
+
+#define ENERGY_COUNT_X_COORD = 160
+#define ENERGY_COUNT_Y_COORD = (SCREEN_HEIGHT - 18);
+
+/* These define the size of the digits used in the ammo/energy display */
+#define BORDER_CHAR_WIDTH 8
+#define BORDER_CHAR_HEIGHT 7
+
 extern void unLHA(REG(a0, void *dst), REG(d0, const void *src), REG(d1, ULONG length), REG(a1, void *workspace),
                   REG(a2, void *X));
 
-extern const UBYTE draw_BorderPacked_vb[];
 extern ULONG Sys_Workspace_vl[];
+extern const UBYTE draw_BorderPacked_vb[];
+extern UBYTE draw_BorderChars_vb[];
+extern UWORD draw_DisplayEnergyCount_w;
+extern UWORD draw_DisplayAmmoCount_w;
 
 static UBYTE draw_Border[SCREEN_WIDTH * SCREEN_HEIGHT];
+
+/* Border digits when not low on ammo/health */
+static UBYTE draw_BorderDigitsGood[BORDER_CHAR_WIDTH * BORDER_CHAR_HEIGHT * 10];
+
+/* Border digits when low on ammo/health */
+static UBYTE draw_BorderDigitsWarn[BORDER_CHAR_WIDTH * BORDER_CHAR_HEIGHT * 10];
+
 static UBYTE *FastBufferAllocPtr;
 
-static void PlanarToChunky(UBYTE *chunky, const PLANEPTR *planes, ULONG numPixels);
+
+static void draw_ConvertLargeBorderDigits(UBYTE* chunky, const UBYTE *planar);
+static void draw_PlanarToChunky(UBYTE *chunky, const PLANEPTR *planes, ULONG numPixels);
+static void draw_ValueToDigits(UWORD value, UWORD digits[3]);
+static void draw_LargeBorderDigitRTG(UBYTE* drawPtr, const UBYTE *glyphs, ULONG digit);
+
+/**********************************************************************************************************************/
 
 BOOL Draw_Init()
 {
@@ -41,7 +67,17 @@ BOOL Draw_Init()
     };
 
     // The image we have has a fixed size
-    PlanarToChunky(draw_Border, planes, SCREEN_WIDTH * SCREEN_HEIGHT);
+    draw_PlanarToChunky(draw_Border, planes, SCREEN_WIDTH * SCREEN_HEIGHT);
+
+	draw_ConvertLargeBorderDigits(
+		draw_BorderDigitsWarn,
+		draw_BorderChars_vb + 15 * BORDER_CHAR_WIDTH * 10
+	);
+
+	draw_ConvertLargeBorderDigits(
+		draw_BorderDigitsGood,
+		draw_BorderChars_vb + 15 * BORDER_CHAR_WIDTH * 10 + BORDER_CHAR_HEIGHT*BORDER_CHAR_WIDTH * 10
+	);
 
     return TRUE;
 
@@ -58,28 +94,6 @@ void Draw_Shutdown()
     }
 }
 
-static void PlanarToChunky(UBYTE *chunky, PLANEPTR const *planes, ULONG numPixels)
-{
-    PLANEPTR pptr[8];
-    memcpy(pptr, planes, sizeof(pptr));
-
-    for (ULONG x = 0; x < numPixels / 8; ++x) {
-        for (BYTE p = 0; p < 8; ++p) {
-            chunky[p] = 0;
-            UBYTE bit = 1 << (7 - p);
-            for (BYTE b = 0; b < 8; ++b) {
-                if (*pptr[b] & bit) {
-                    chunky[p] |= 1 << b;
-                }
-            }
-        }
-        chunky += 8;
-        for (BYTE p = 0; p < 8; ++p) {
-            pptr[p]++;
-        }
-    }
-}
-
 void Draw_ResetGameDisplay()
 {
     if (!Vid_isRTG) {
@@ -93,8 +107,14 @@ void Draw_ResetGameDisplay()
         ULONG bmBytesPerRow;
         APTR bmBaseAdress;
 
-        APTR bmHandle = LockBitMapTags(Vid_MainScreen_l->ViewPort.RasInfo->BitMap, LBMI_BYTESPERROW,
-                                       (ULONG)&bmBytesPerRow, LBMI_BASEADDRESS, (ULONG)&bmBaseAdress, TAG_DONE);
+        APTR bmHandle = LockBitMapTags(
+			Vid_MainScreen_l->ViewPort.RasInfo->BitMap,
+			LBMI_BYTESPERROW,
+			(ULONG)&bmBytesPerRow,
+			LBMI_BASEADDRESS,
+			(ULONG)&bmBaseAdress,
+			TAG_DONE
+		);
         if (bmHandle) {
             const UBYTE *src = draw_Border;
             WORD height = Vid_ScreenHeight < SCREEN_HEIGHT ? Vid_ScreenHeight : SCREEN_HEIGHT;
@@ -119,14 +139,111 @@ void Draw_LineOfText(REG(a0, const char *ptr), REG(a1, APTR screenPointer), REG(
 
 }
 
-
 void Draw_BorderAmmoBar()
 {
+    if (!Vid_isRTG) {
+		return;
+	}
+	LOCAL_CYBERGFX();
 
+	ULONG bmBytesPerRow;
+	APTR bmBaseAdress;
+
+	APTR bmHandle = LockBitMapTags(
+		Vid_MainScreen_l->ViewPort.RasInfo->BitMap,
+		LBMI_BYTESPERROW,
+		(ULONG)&bmBytesPerRow,
+		LBMI_BASEADDRESS,
+		(ULONG)&bmBaseAdress,
+		TAG_DONE
+	);
+	if (bmHandle) {
+		UWORD digits[3];
+
+		draw_ValueToDigits(draw_DisplayAmmoCount_w, digits);
+		const UBYTE *glyphs = draw_DisplayAmmoCount_w > 9 ? draw_BorderDigitsGood : draw_BorderDigitsWarn;
+
+		ULONG offset = AMMO_COUNT_X_COORD + AMMO_COUNT_Y_COORD * SCREEN_WIDTH;
+
+		UBYTE *drawPtr = (UBYTE*)bmBaseAdress;
+
+		for (int i=0; i < 3; ++i, offset += 8) {
+			draw_LargeBorderDigitRTG(drawPtr + offset, glyphs, digits[i]);
+		}
+		UnLockBitMap(bmHandle);
+	}
 }
 
 
 void Draw_BorderEnergyBar()
 {
 
+}
+
+/**********************************************************************************************************************/
+
+static void draw_PlanarToChunky(UBYTE *chunky, PLANEPTR const *planes, ULONG numPixels)
+{
+    PLANEPTR pptr[8];
+    memcpy(pptr, planes, sizeof(pptr));
+
+    for (ULONG x = 0; x < numPixels / 8; ++x) {
+        for (BYTE p = 0; p < 8; ++p) {
+            chunky[p] = 0;
+            UBYTE bit = 1 << (7 - p);
+            for (BYTE b = 0; b < 8; ++b) {
+                if (*pptr[b] & bit) {
+                    chunky[p] |= 1 << b;
+                }
+            }
+        }
+        chunky += 8;
+        for (BYTE p = 0; p < 8; ++p) {
+            pptr[p]++;
+        }
+    }
+}
+
+/**
+ * Converts the border digits used for ammo/health from their initial planar representation to a chunky one
+ */
+static void draw_ConvertLargeBorderDigits(UBYTE* chunky_output, const UBYTE *planar_input) {
+
+    PLANEPTR planes[8];
+
+	const UBYTE *base_digit = planar_input;
+	UBYTE *out_digit  = chunky_output;
+    for (int d = 0; d < 10; ++d) {
+        const UBYTE *digit = base_digit + d;
+		for (int p = 0; p < 8; ++p) {
+			planes[p] = (PLANEPTR)(digit + p * 10);
+		}
+
+		for (int y = 0; y <  BORDER_CHAR_HEIGHT; ++y) {
+			draw_PlanarToChunky(out_digit, planes, BORDER_CHAR_WIDTH);
+			for (int p = 0; p < 8; ++p) {
+				planes[p] += BORDER_CHAR_WIDTH * 10;
+			}
+			out_digit += BORDER_CHAR_WIDTH;
+		}
+    }
+}
+
+static void draw_LargeBorderDigitRTG(UBYTE* drawPtr, const UBYTE *glyphs, ULONG digit) {
+	const UBYTE *digitPtr = &glyphs[digit * BORDER_CHAR_WIDTH * BORDER_CHAR_HEIGHT];
+	for (int y = 0; y < BORDER_CHAR_HEIGHT; ++y) {
+	    for (int x=0; x < BORDER_CHAR_WIDTH; ++x) {
+		    drawPtr[x] = *digitPtr++;
+		}
+		drawPtr += SCREEN_WIDTH;
+	}
+}
+
+static void draw_ValueToDigits(UWORD value, UWORD digits[3]) {
+	if (value > 999) {
+		value = 999;
+	}
+	digits[2] = value % 10; value /= 10;
+	digits[1] = value % 10; value /= 10;
+	digits[0] = value;
 }

--- a/ab3d2_source/c/draw.h
+++ b/ab3d2_source/c/draw.h
@@ -4,13 +4,17 @@
 #include <exec/types.h>
 #include "screen.h"
 
-/* These are the positions in the border for the ammo and health glyphs to be rendered */
+/**
+ * These are the positions in the border for the ammo and health glyphs to be rendered
+ *
+ * Negative values are relative to the right / bottom of the display.
+ */
 #define DRAW_HUD_AMMO_COUNT_X 160
-#define DRAW_HUD_AMMO_COUNT_Y (SCREEN_HEIGHT - 18)
+#define DRAW_HUD_AMMO_COUNT_Y -18
 #define DRAW_HUD_ENERGY_COUNT_X 272
-#define DRAW_HUD_ENERGY_COUNT_Y (SCREEN_HEIGHT - 18)
+#define DRAW_HUD_ENERGY_COUNT_Y -18
 #define DRAW_HUD_ITEM_SLOTS_X 24
-#define DRAW_HUD_ITEM_SLOTS_Y (SCREEN_HEIGHT - 16)
+#define DRAW_HUD_ITEM_SLOTS_Y -16
 
 
 /* These define the size of the digits used in the ammo/energy display */
@@ -23,6 +27,11 @@
 
 #define DRAW_COUNT_W (3 * DRAW_HUD_CHAR_W)
 #define DRAW_NUM_WEAPON_SLOTS 10
+
+/* These define limits for when the displayed count*/
+#define LOW_AMMO_COUNT_WARN_LIMIT 9
+#define LOW_ENERGY_COUNT_WARN_LIMIT 9
+#define DISPLAY_COUNT_LIMIT 999
 
 extern void Draw_ResetGameDisplay(void);
 extern BOOL Draw_Init(void);

--- a/ab3d2_source/c/draw.h
+++ b/ab3d2_source/c/draw.h
@@ -6,6 +6,8 @@
 extern void Draw_ResetGameDisplay(void);
 extern BOOL Draw_Init(void);
 extern void Draw_Shutdown(void);
+extern void Draw_UpdateBorder_RTG(APTR bmHandle, ULONG bmBytesPerRow);
+extern void Draw_UpdateBorder_Planar(void);
 
 extern UBYTE *Vid_FastBufferPtr_l;
 

--- a/ab3d2_source/c/draw.h
+++ b/ab3d2_source/c/draw.h
@@ -2,6 +2,27 @@
 #define DRAW_H
 
 #include <exec/types.h>
+#include "screen.h"
+
+/* These are the positions in the border for the ammo and health glyphs to be rendered */
+#define DRAW_HUD_AMMO_COUNT_X 160
+#define DRAW_HUD_AMMO_COUNT_Y (SCREEN_HEIGHT - 18)
+#define DRAW_HUD_ENERGY_COUNT_X 272
+#define DRAW_HUD_ENERGY_COUNT_Y (SCREEN_HEIGHT - 18)
+#define DRAW_HUD_ITEM_SLOTS_X 24
+#define DRAW_HUD_ITEM_SLOTS_Y (SCREEN_HEIGHT - 16)
+
+
+/* These define the size of the digits used in the ammo/energy display */
+#define DRAW_HUD_CHAR_W 8
+#define DRAW_HUD_CHAR_H 7
+
+/* These define the size of the digits used in the item list display */
+#define DRAW_HUD_CHAR_SMALL_W 8
+#define DRAW_HUD_CHAR_SMALL_H 5
+
+#define DRAW_COUNT_W (3 * DRAW_HUD_CHAR_W)
+#define DRAW_NUM_WEAPON_SLOTS 10
 
 extern void Draw_ResetGameDisplay(void);
 extern BOOL Draw_Init(void);

--- a/ab3d2_source/c/screen.c
+++ b/ab3d2_source/c/screen.c
@@ -74,16 +74,14 @@ BOOL Vid_OpenMainScreen(void)
         Vid_Screen1Ptr_l = bitmaps[0].Planes[0];
         Vid_Screen2Ptr_l = bitmaps[1].Planes[0];
 
-        if (!(Vid_MainScreen_l = OpenScreenTags(
-			NULL, SA_Width, SCREEN_WIDTH, SA_Height, SCREEN_HEIGHT, SA_Depth, 8, SA_BitMap,
-			(Tag)&bitmaps[0], SA_Type, CUSTOMSCREEN, SA_Quiet, 1,
+        if (!(Vid_MainScreen_l = OpenScreenTags(NULL, SA_Width, SCREEN_WIDTH, SA_Height, SCREEN_HEIGHT, SA_Depth, 8, SA_BitMap,
+                                                (Tag)&bitmaps[0], SA_Type, CUSTOMSCREEN, SA_Quiet, 1,
 #ifdef SCREEN_TITLEBAR_HACK
-			SA_ShowTitle, 0,
+                                                SA_ShowTitle, 0,
 #else
-			SA_ShowTitle, 1,
+			                                    SA_ShowTitle, 1,
 #endif
-			SA_AutoScroll, 0, SA_FullPalette, 1, SA_DisplayID, Vid_ScreenMode, TAG_END, 0))
-		) {
+			                                    SA_AutoScroll, 0, SA_FullPalette, 1, SA_DisplayID, Vid_ScreenMode, TAG_END, 0))) {
             goto fail;
         };
 
@@ -111,8 +109,10 @@ BOOL Vid_OpenMainScreen(void)
         // FreeVPortCopLists/CloseScreen assumes UCopList's are allocated with AllocMem
         // See note in Vid_CloseMainScreen
         doubleHeightCopList = AllocMem(sizeof(*doubleHeightCopList), MEMF_PUBLIC|MEMF_CLEAR);
-        if (!doubleHeightCopList)
+        if (!doubleHeightCopList) {
             goto fail;
+        }
+
         CINIT(doubleHeightCopList, 116 * 6 + 4);  // 232 modulos
 
         int line;
@@ -157,12 +157,10 @@ BOOL Vid_OpenMainScreen(void)
         }
     }
 
-    if (!(Vid_MainWindow_l = OpenWindowTags(
-		NULL, WA_Left, 0, WA_Top, 0, WA_Width, SCREEN_WIDTH, WA_Height,
-		SCREEN_HEIGHT, WA_CustomScreen, (Tag)Vid_MainScreen_l, WA_Activate, 1,
-		WA_Borderless, 1, WA_RMBTrap, 1,  // prevent menu rendering
-		WA_NoCareRefresh, 1, WA_SimpleRefresh, 1, WA_Backdrop, 1, TAG_END, 0))
-	) {
+    if (!(Vid_MainWindow_l = OpenWindowTags(NULL, WA_Left, 0, WA_Top, 0, WA_Width, SCREEN_WIDTH, WA_Height,
+                                            SCREEN_HEIGHT, WA_CustomScreen, (Tag)Vid_MainScreen_l, WA_Activate, 1,
+                                            WA_Borderless, 1, WA_RMBTrap, 1,  // prevent menu rendering
+                                            WA_NoCareRefresh, 1, WA_SimpleRefresh, 1, WA_Backdrop, 1, TAG_END, 0))) {
         goto fail;
     }
 
@@ -392,17 +390,11 @@ void Vid_Present()
         UBYTE *bmdata;
         ULONG bmBytesPerRow;
         ULONG bmHeight;
-        APTR bmHandle = LockBitMapTags(
-            Vid_MainScreen_l->ViewPort.RasInfo->BitMap,
-            LBMI_BYTESPERROW,
-            (ULONG)&bmBytesPerRow,
-            LBMI_BASEADDRESS,
-            (ULONG)&bmdata,
-            LBMI_HEIGHT,
-            (ULONG)&bmHeight,
-            TAG_DONE
-        );
-
+        APTR bmHandle = LockBitMapTags(Vid_MainScreen_l->ViewPort.RasInfo->BitMap,
+                                       LBMI_BYTESPERROW, (ULONG)&bmBytesPerRow,
+                                       LBMI_BASEADDRESS, (ULONG)&bmdata,
+                                       LBMI_HEIGHT, (ULONG)&bmHeight,
+                                       TAG_DONE);
         if (bmHandle) {
             if (Vid_FullScreen_b) {
                 WORD height = FS_C2P_HEIGHT - Vid_LetterBoxMarginHeight_w * 2;

--- a/ab3d2_source/c/screen.c
+++ b/ab3d2_source/c/screen.c
@@ -382,7 +382,7 @@ static void CopyFrameBuffer(UBYTE *dst, const UBYTE *src, WORD dstBytesPerRow, W
     }
 }
 
-extern void Draw_BorderAmmoBar(void);
+extern void Draw_UpdateBorder_RTG(APTR bmBaseAdress, ULONG bmBytesPerRow);
 
 void Vid_Present()
 {
@@ -392,9 +392,16 @@ void Vid_Present()
         UBYTE *bmdata;
         ULONG bmBytesPerRow;
         ULONG bmHeight;
-        APTR bmHandle =
-            LockBitMapTags(Vid_MainScreen_l->ViewPort.RasInfo->BitMap, LBMI_BYTESPERROW, (ULONG)&bmBytesPerRow,
-                           LBMI_BASEADDRESS, (ULONG)&bmdata, LBMI_HEIGHT, (ULONG)&bmHeight, TAG_DONE);
+        APTR bmHandle = LockBitMapTags(
+            Vid_MainScreen_l->ViewPort.RasInfo->BitMap,
+            LBMI_BYTESPERROW,
+            (ULONG)&bmBytesPerRow,
+            LBMI_BASEADDRESS,
+            (ULONG)&bmdata,
+            LBMI_HEIGHT,
+            (ULONG)&bmHeight,
+            TAG_DONE
+        );
 
         if (bmHandle) {
             if (Vid_FullScreen_b) {
@@ -403,8 +410,13 @@ void Vid_Present()
                 BYTE *dst = bmdata + topOffsett;
                 const BYTE *src = Vid_FastBufferPtr_l + topOffsett;
 
-                if ((FS_WIDTH == SCREEN_WIDTH) && (bmBytesPerRow == SCREEN_WIDTH) && Vid_FullScreen_b &&
-                    !Vid_DoubleHeight_b && !Vid_DoubleWidth_b) {
+                if (
+                    (FS_WIDTH == SCREEN_WIDTH) &&
+                    (bmBytesPerRow == SCREEN_WIDTH) &&
+                    Vid_FullScreen_b &&
+                    !Vid_DoubleHeight_b &&
+                    !Vid_DoubleWidth_b
+                ) {
                     CopyMemQuick(src, dst, SCREEN_WIDTH * height);
                 } else {
                     CopyFrameBuffer(dst, src, bmBytesPerRow, SCREEN_WIDTH, height);
@@ -417,6 +429,9 @@ void Vid_Present()
 
                 CopyFrameBuffer(dst, src, bmBytesPerRow, SMALL_WIDTH, height);
             }
+
+            Draw_UpdateBorder_RTG(bmdata, bmBytesPerRow);
+
             UnLockBitMap(bmHandle);
         } else {
             KPrintF("Could not lock bitmap\n");

--- a/ab3d2_source/c/screen.c
+++ b/ab3d2_source/c/screen.c
@@ -74,15 +74,16 @@ BOOL Vid_OpenMainScreen(void)
         Vid_Screen1Ptr_l = bitmaps[0].Planes[0];
         Vid_Screen2Ptr_l = bitmaps[1].Planes[0];
 
-        if (!(Vid_MainScreen_l =
-                  OpenScreenTags(NULL, SA_Width, SCREEN_WIDTH, SA_Height, SCREEN_HEIGHT, SA_Depth, 8, SA_BitMap,
-                                 (Tag)&bitmaps[0], SA_Type, CUSTOMSCREEN, SA_Quiet, 1,
+        if (!(Vid_MainScreen_l = OpenScreenTags(
+			NULL, SA_Width, SCREEN_WIDTH, SA_Height, SCREEN_HEIGHT, SA_Depth, 8, SA_BitMap,
+			(Tag)&bitmaps[0], SA_Type, CUSTOMSCREEN, SA_Quiet, 1,
 #ifdef SCREEN_TITLEBAR_HACK
-                                 SA_ShowTitle, 0,
+			SA_ShowTitle, 0,
 #else
-                                 SA_ShowTitle, 1,
+			SA_ShowTitle, 1,
 #endif
-                                 SA_AutoScroll, 0, SA_FullPalette, 1, SA_DisplayID, Vid_ScreenMode, TAG_END, 0))) {
+			SA_AutoScroll, 0, SA_FullPalette, 1, SA_DisplayID, Vid_ScreenMode, TAG_END, 0))
+		) {
             goto fail;
         };
 
@@ -156,10 +157,12 @@ BOOL Vid_OpenMainScreen(void)
         }
     }
 
-    if (!(Vid_MainWindow_l = OpenWindowTags(NULL, WA_Left, 0, WA_Top, 0, WA_Width, SCREEN_WIDTH, WA_Height,
-                                            SCREEN_HEIGHT, WA_CustomScreen, (Tag)Vid_MainScreen_l, WA_Activate, 1,
-                                            WA_Borderless, 1, WA_RMBTrap, 1,  // prevent menu rendering
-                                            WA_NoCareRefresh, 1, WA_SimpleRefresh, 1, WA_Backdrop, 1, TAG_END, 0))) {
+    if (!(Vid_MainWindow_l = OpenWindowTags(
+		NULL, WA_Left, 0, WA_Top, 0, WA_Width, SCREEN_WIDTH, WA_Height,
+		SCREEN_HEIGHT, WA_CustomScreen, (Tag)Vid_MainScreen_l, WA_Activate, 1,
+		WA_Borderless, 1, WA_RMBTrap, 1,  // prevent menu rendering
+		WA_NoCareRefresh, 1, WA_SimpleRefresh, 1, WA_Backdrop, 1, TAG_END, 0))
+	) {
         goto fail;
     }
 
@@ -378,6 +381,8 @@ static void CopyFrameBuffer(UBYTE *dst, const UBYTE *src, WORD dstBytesPerRow, W
         }
     }
 }
+
+extern void Draw_BorderAmmoBar(void);
 
 void Vid_Present()
 {

--- a/ab3d2_source/c/screen.h
+++ b/ab3d2_source/c/screen.h
@@ -6,6 +6,11 @@
 #define SCREEN_WIDTH (UWORD)320
 #define SCREEN_HEIGHT (UWORD)256
 
+/**
+ * Define RTG_LONG_ALIGNED if you expect to perform 32-bit access to VRAM only
+ */
+#define RTG_LONG_ALIGNED
+
 #ifndef FS_HEIGHT_HACK
 #define FS_HEIGHT (SCREEN_HEIGHT - (UWORD)16)
 #define FS_HEIGHT_C2P_DIFF (UWORD)8

--- a/ab3d2_source/controlloop.s
+++ b/ab3d2_source/controlloop.s
@@ -756,11 +756,11 @@ TWOPLAYER:
 				rts
 
 				move.w	#0,OldEnergy
-				move.w	#127,Energy
+				move.w	#127,draw_DisplayEnergyCount_w
 				CALLC	Draw_BorderEnergyBar
 
 				move.w	#63,OldAmmo
-				move.w	#0,Ammo
+				move.w	#0,draw_DisplayAmmoCount_w
 				CALLC	Draw_BorderAmmoBar
 				move.w	#0,OldAmmo
 

--- a/ab3d2_source/controlloop.s
+++ b/ab3d2_source/controlloop.s
@@ -745,7 +745,7 @@ TWOPLAYER:
 				move.l	#Plr1_AmmoCounts_vw,a0
 				move.l	#Plr2_AmmoCounts_vw,a1
 				move.w	#19,d1
-.putinvals
+.putinvals:
 				jsr		GetRand
 				and.w	#63,d0
 				add.w	#5,d0
@@ -755,17 +755,13 @@ TWOPLAYER:
 
 				rts
 
-				move.w	#0,OldEnergy
 				move.w	#127,draw_DisplayEnergyCount_w
 				CALLC	Draw_BorderEnergyBar
 
-				move.w	#63,OldAmmo
 				move.w	#0,draw_DisplayAmmoCount_w
 				CALLC	Draw_BorderAmmoBar
-				move.w	#0,OldAmmo
 
 				move.b	#0,Plr1_GunSelected_b
-
 				move.b	#0,Plr2_GunSelected_b
 				rts
 

--- a/ab3d2_source/data/draw_data.s
+++ b/ab3d2_source/data/draw_data.s
@@ -32,6 +32,7 @@ draw_FontPtrs_vl:
 				dc.l	ENDFONT2,CHARWIDTHS2
 
 				align 4
+_draw_BorderChars_vb::
 draw_BorderChars_vb:
 				incbin	"includes/bordercharsraw"
 

--- a/ab3d2_source/hires.s
+++ b/ab3d2_source/hires.s
@@ -1074,10 +1074,10 @@ okwat:
 
 				move.l	#Plr1_AmmoCounts_vw,a6
 				move.w	(a6,d0.w*2),d0
-				move.w	d0,Ammo
+				move.w	d0,draw_DisplayAmmoCount_w
 				movem.l	(a7)+,d0-d7/a0-a6
 
-				move.w	Plr1_Health_w,Energy
+				move.w	Plr1_Health_w,draw_DisplayEnergyCount_w
 
 				move.w	Anim_FramesToDraw_w,Anim_TempFrames_w
 				cmp.w	#15,Anim_TempFrames_w
@@ -1154,7 +1154,7 @@ NotOnePlayer:
 				sne		Game_MasterPaused_b
 
 *********************************
-				move.w	Plr1_Health_w,Energy
+				move.w	Plr1_Health_w,draw_DisplayEnergyCount_w
 ; change this back
 *********************************
 				movem.l	d0-d7/a0-a6,-(a7)
@@ -1167,7 +1167,7 @@ NotOnePlayer:
 
 				move.l	#Plr1_AmmoCounts_vw,a6
 				move.w	(a6,d0.w*2),d0
-				move.w	d0,Ammo
+				move.w	d0,draw_DisplayAmmoCount_w
 				movem.l	(a7)+,d0-d7/a0-a6
 
 				jsr		SENDFIRST
@@ -1287,10 +1287,10 @@ ASlaveShouldWaitOnHisMaster:
 
 				move.l	#Plr2_AmmoCounts_vw,a6
 				move.w	(a6,d0.w*2),d0
-				move.w	d0,Ammo
+				move.w	d0,draw_DisplayAmmoCount_w
 				movem.l	(a7)+,d0-d7/a0-a6
 
-				move.w	Plr2_Health_w,Energy
+				move.w	Plr2_Health_w,draw_DisplayEnergyCount_w
 
 				jsr		RECFIRST
 
@@ -5015,10 +5015,10 @@ endlevel:
 ;				move.w	#$f,$dff000+dmacon
 
 
-				move.w	Plr1_Health_w,Energy
+				move.w	Plr1_Health_w,draw_DisplayEnergyCount_w
 				cmp.b	#PLR_SLAVE,Plr_MultiplayerType_b
 				bne.s	.notsl
-				move.w	Plr2_Health_w,Energy
+				move.w	Plr2_Health_w,draw_DisplayEnergyCount_w
 .notsl:
 
 ; cmp.b #'b',Prefsfile+3
@@ -5026,9 +5026,9 @@ endlevel:
 ; jsr mt_end
 ;.noback
 
-				tst.w	Energy
+				tst.w	draw_DisplayEnergyCount_w
 				bgt.s	wevewon
-				move.w	#0,Energy
+				move.w	#0,draw_DisplayEnergyCount_w
 				CALLC	Draw_BorderEnergyBar
 
 				move.l	#gameover,mt_data

--- a/ab3d2_source/modules/draw.s
+++ b/ab3d2_source/modules/draw.s
@@ -14,13 +14,6 @@ draw_NarrateTextTime_w:
 				dc.w	5
 
 ; move me
-_draw_DisplayEnergyCount_w::
-draw_DisplayEnergyCount_w: dc.w	191
-
-
-_draw_DisplayAmmoCount_w::
-draw_DisplayAmmoCount_w:	dc.w	63
-
 firstdigit_b:	dc.b	0
 secdigit_b:		dc.b	0
 thirddigit_b:	dc.b	0

--- a/ab3d2_source/modules/draw.s
+++ b/ab3d2_source/modules/draw.s
@@ -13,10 +13,13 @@
 draw_NarrateTextTime_w:
 				dc.w	5
 
-; move me
-Energy:			dc.w	191
+; move me#
+_draw_DisplayEnergyCount_w::
+draw_DisplayEnergyCount_w: dc.w	191
 OldEnergy:		dc.w	191
-Ammo:			dc.w	63
+
+_draw_DisplayAmmoCount_w::
+draw_DisplayAmmoCount_w:	dc.w	63
 OldAmmo:		dc.w	63
 
 firstdigit_b:	dc.b	0
@@ -156,7 +159,7 @@ Draw_BorderAmmoBar:
 				addq	#1,d0
 				dbra	d2,.putingunnums
 
-				move.w	Ammo,d0
+				move.w	draw_DisplayAmmoCount_w,d0
 
 				cmp.w	#999,d0
 				blt.s	.okammo
@@ -175,7 +178,7 @@ Draw_BorderAmmoBar:
 				move.b	d0,secdigit_b
 
 				move.l	#draw_BorderChars_vb+15*8*10,a0
-				cmp.w	#10,Ammo
+				cmp.w	#10,draw_DisplayAmmoCount_w
 				blt.s	.notsmallamo
 				add.l	#7*8*10,a0
 .notsmallamo:
@@ -203,7 +206,7 @@ Draw_BorderAmmoBar:
 
 ;
 Draw_BorderEnergyBar:
-				move.w	Energy,d0
+				move.w	draw_DisplayEnergyCount_w,d0
 				bge.s	.okpo
 				moveq	#0,d0
 .okpo:
@@ -225,7 +228,7 @@ Draw_BorderEnergyBar:
 				move.b	d0,secdigit_b
 
 				move.l	#draw_BorderChars_vb+15*8*10,a0
-				cmp.w	#10,Energy
+				cmp.w	#10,draw_DisplayEnergyCount_w
 				blt.s	.notsmallamo
 				add.l	#7*8*10,a0
 .notsmallamo:
@@ -268,7 +271,14 @@ Draw_BorderEnergyBar:
 
 				rts
 
-
+; Draws an 8x7 (?) digit for the draw_DisplayAmmoCount_w / Health counters
+; a1 points to first plane offset (coordinates are aligned to byte locations)
+; a2 points to source digit defintion on the first plane
+; d0 contains the digit
+; d1 contains the pixel height of the glyph
+;
+; Destination planes are separated by 320 * 256 / 8 = 10240 bytes
+; Source planes are separated by 80 bytes
 draw_BorderDigit:
 				ext.w	d0
 				lea		(a0,d0.w),a2
@@ -285,8 +295,8 @@ draw_BorderDigit:
 				move.b	60(a2),(a3)
 				move.b	70(a2),10240(a3)
 
-				add.w	#10*8,a2
-				add.w	#40,a1
+				add.w	#10*8,a2 ; next source scanline
+				add.w	#40,a1   ; next destination scanline
 				dbra	d1,.charlines
 
 				rts

--- a/ab3d2_source/modules/draw.s
+++ b/ab3d2_source/modules/draw.s
@@ -13,14 +13,13 @@
 draw_NarrateTextTime_w:
 				dc.w	5
 
-; move me#
+; move me
 _draw_DisplayEnergyCount_w::
 draw_DisplayEnergyCount_w: dc.w	191
-OldEnergy:		dc.w	191
+
 
 _draw_DisplayAmmoCount_w::
 draw_DisplayAmmoCount_w:	dc.w	63
-OldAmmo:		dc.w	63
 
 firstdigit_b:	dc.b	0
 secdigit_b:		dc.b	0


### PR DESCRIPTION
Reintroduces the border digits display in the RTG build
- Embedded planar glyphs are preconverted during startup
- Weapon list, ammo and health displays are rendered into a mini buffer
- Minibuffer is block copied to the bitmap after the main display is rendered.

A followup PR will address the need perform these tasks when not selecting an RTG mode at startup and use planar rendering direct to the border from the original assets.

![rtg-hud](https://github.com/mheyer32/alienbreed3d2/assets/27722116/c10de866-785e-4597-90a0-888f4caa37c6)

Updates
- Made sure the on-screen coordinates for the glyphs are display height aware
- The item list is only re-rendered if it has changed

Have tested in 320x200, 320x240, 320x256 RTG modes.
