### PR TITLE
Feature/text rendering

### DIFF
--- a/ab3d2_source/bss/draw_bss.s
+++ b/ab3d2_source/bss/draw_bss.s
@@ -100,3 +100,6 @@ draw_WhichDoing_b:				ds.b	1
 draw_InUpperZone_b:				ds.b	1
 Draw_DoUpper_b:					ds.b	1
 Draw_ForceSimpleWalls_b:		ds.b	1
+
+_draw_GlyphSpacing_vb::
+draw_GlyphSpacing_vb:			ds.b    256

--- a/ab3d2_source/c/draw.c
+++ b/ab3d2_source/c/draw.c
@@ -297,30 +297,15 @@ static void draw_ChunkyGlyph(UBYTE *drawPtr, UWORD drawSpan, UBYTE charGlyph, UB
     UBYTE *planarPtr = &draw_ScrollChars_vb[(UWORD)charGlyph << 3];
     for (UWORD row = 0; row < DRAW_MSG_CHAR_H; ++row) {
         UBYTE plane = *planarPtr++;
-        if (plane & 128) {
-            drawPtr[0] = pen;
-        }
-        if (plane & 64) {
-            drawPtr[1] = pen;
-        }
-        if (plane & 32) {
-            drawPtr[2] = pen;
-        }
-        if (plane & 16) {
-            drawPtr[3] = pen;
-        }
-        if (plane & 8) {
-            drawPtr[4] = pen;
-        }
-        if (plane & 4) {
-            drawPtr[5] = pen;
-        }
-        if (plane & 2) {
-            drawPtr[6] = pen;
-        }
-        if (plane & 1) {
-            drawPtr[7] = pen;
-        }
+        if (!plane)      continue;
+        if (plane & 128) drawPtr[0] = pen;
+        if (plane & 64)  drawPtr[1] = pen;
+        if (plane & 32)  drawPtr[2] = pen;
+        if (plane & 16)  drawPtr[3] = pen;
+        if (plane & 8)   drawPtr[4] = pen;
+        if (plane & 4)   drawPtr[5] = pen;
+        if (plane & 2)   drawPtr[6] = pen;
+        if (plane & 1)   drawPtr[7] = pen;
         drawPtr += drawSpan;
     }
 }

--- a/ab3d2_source/c/draw.c
+++ b/ab3d2_source/c/draw.c
@@ -310,7 +310,7 @@ const char* Draw_ChunkyTextFGOnly(
         if ( (charGlyph > 0x20 && charGlyph < 0x7F) || charGlyph > 0xA0) {
             draw_ChunkyGlyphFGOnly(drawPtr, drawSpan, charGlyph, fgPen);
         }
-        drawPtr += DRAW_MSG_CHAR_H;
+        drawPtr += DRAW_MSG_CHAR_W;
     }
     return charGlyph ? textPtr : (const char*)NULL;
 }
@@ -335,7 +335,7 @@ const char* Draw_ChunkyText(
         if ( (charGlyph >= 0x20 && charGlyph < 0x7F) || charGlyph >= 0xA0) {
             draw_ChunkyGlyph(drawPtr, drawSpan, charGlyph, fgPen, bgPen);
         }
-        drawPtr += DRAW_MSG_CHAR_H;
+        drawPtr += DRAW_MSG_CHAR_W;
     }
     return charGlyph ? textPtr : (const char*)NULL;
 }

--- a/ab3d2_source/c/draw.c
+++ b/ab3d2_source/c/draw.c
@@ -258,34 +258,20 @@ static void draw_CalculateGlyphSpacing() {
 
         /* If the mask is zero, it means the glyph is empty. Assume the same space as the space glyph */
         if (mask) {
-            // Identify the left offset.
-            UBYTE position = 0;
-            BYTE bit      = 7;
-            while (bit-- >= 0) {
-                if (mask & (1 << bit)) {
-                    break;
-                }
-                ++position;
+            UBYTE tmp = mask;
+            while (!(tmp & 0x80)) {
+                ++left;
+                tmp <<= 1;
             }
-            left = position;
-
-            // Determine the width.
-            position = 8;
-            bit      = 0;
-            while (bit++ < 8) {
-                if (mask & (1 << bit)) {
-                    break;
-                }
-                --position;
+            tmp = 0;
+            while (!(mask & 0x01)) {
+                ++tmp;
+                mask >>= 1;
             }
-            width = position - left;
+            width = 9 - left - tmp;
         }
         draw_GlyphSpacing_vb[i] = width << 4 | left;
     }
-
-    /* Kludges */
-    draw_GlyphSpacing_vb[(UBYTE)'r'] = 0x51;
-    draw_GlyphSpacing_vb[(UBYTE)'t'] = 0x41;
 }
 
 /**
@@ -297,15 +283,16 @@ static void draw_ChunkyGlyph(UBYTE *drawPtr, UWORD drawSpan, UBYTE charGlyph, UB
     UBYTE *planarPtr = &draw_ScrollChars_vb[(UWORD)charGlyph << 3];
     for (UWORD row = 0; row < DRAW_MSG_CHAR_H; ++row) {
         UBYTE plane = *planarPtr++;
-        if (!plane)      continue;
-        if (plane & 128) drawPtr[0] = pen;
-        if (plane & 64)  drawPtr[1] = pen;
-        if (plane & 32)  drawPtr[2] = pen;
-        if (plane & 16)  drawPtr[3] = pen;
-        if (plane & 8)   drawPtr[4] = pen;
-        if (plane & 4)   drawPtr[5] = pen;
-        if (plane & 2)   drawPtr[6] = pen;
-        if (plane & 1)   drawPtr[7] = pen;
+            if (plane) {
+            if (plane & 128) drawPtr[0] = pen;
+            if (plane & 64)  drawPtr[1] = pen;
+            if (plane & 32)  drawPtr[2] = pen;
+            if (plane & 16)  drawPtr[3] = pen;
+            if (plane & 8)   drawPtr[4] = pen;
+            if (plane & 4)   drawPtr[5] = pen;
+            if (plane & 2)   drawPtr[6] = pen;
+            if (plane & 1)   drawPtr[7] = pen;
+        }
         drawPtr += drawSpan;
     }
 }

--- a/ab3d2_source/c/draw.c
+++ b/ab3d2_source/c/draw.c
@@ -298,7 +298,7 @@ static void draw_ChunkyGlyph(UBYTE *drawPtr, UWORD drawSpan, UBYTE charGlyph, UB
 }
 
 /**
- * Draw a length limited, null terminated string of fixed glyphs at a given coordinate, foreground only.
+ * Draw a length limited, null terminated string of fixed glyphs at a given coordinate.
  */
 const char* Draw_ChunkyText(
     UBYTE *drawPtr,
@@ -322,7 +322,7 @@ const char* Draw_ChunkyText(
 }
 
 /**
- * Draw a length limited, null terminated string of fixed glyphs at a given coordinate, foreground only.
+ * Draw a length limited, null terminated string of proportional glyphs at a given coordinate.
  */
 const char* Draw_ChunkyTextProp(
     UBYTE *drawPtr,
@@ -341,10 +341,22 @@ const char* Draw_ChunkyTextProp(
         if ( (charGlyph > 0x20 && charGlyph < 0x7F) || charGlyph > 0xA0) {
             draw_ChunkyGlyph(drawPtr - (glyphSpacing & 0xF), drawSpan, charGlyph, pen);
         }
-        //drawPtr += DRAW_MSG_CHAR_W;
         drawPtr += glyphSpacing >> 4;
     }
     return charGlyph ? textPtr : (const char*)NULL;
+}
+
+/**
+ * Calculate the pixel width of a string (up to maxLen or null, whichever comes first) when using proportional
+ * rendering.
+ */
+ULONG Draw_CalcPropWidth(const char *textPtr, UWORD maxLen) {
+    ULONG width = 0;
+    UBYTE charGlyph;
+    while ( (charGlyph = (UBYTE)*textPtr++) && maxLen-- > 0 ) {
+        width += draw_GlyphSpacing_vb[charGlyph] >> 4;
+    }
+    return width;
 }
 
 /**

--- a/ab3d2_source/c/draw.c
+++ b/ab3d2_source/c/draw.c
@@ -73,6 +73,8 @@ static void draw_ConvertPlanarDigits(UBYTE* chunky, const UBYTE *planar, UWORD w
 static void draw_RenderCounterDigit_RTG(UBYTE *drawPtr, const UBYTE *glyphs, UWORD digit, UWORD span);
 static void draw_RenderItemDigit_RTG(UBYTE *drawPtr, const UBYTE *glyphs, UWORD digit, UWORD span);
 
+static void draw_CalculateGlyphSpacing(void);
+
 static void draw_UpdateCounter_RTG(
     APTR bmBaseAddress,
     ULONG bmBytesPerRow,
@@ -168,6 +170,8 @@ BOOL Draw_Init()
 
     }
 
+    draw_CalculateGlyphSpacing();
+
     draw_ResetHUDCounters();
     return TRUE;
 
@@ -233,90 +237,78 @@ void Draw_ResetGameDisplay()
 
 /**********************************************************************************************************************/
 
+extern UBYTE draw_GlyphSpacing_vb[256];
+
+static void draw_CalculateGlyphSpacing() {
+    UBYTE *glyphPtr = draw_ScrollChars_vb;
+    for (UWORD i = 0; i < 256; ++i, glyphPtr += 8) {
+        UBYTE left  = 0;
+        UBYTE width = 4;
+        UBYTE mask  = glyphPtr[0] | glyphPtr[1] | glyphPtr[2] | glyphPtr[3] |
+                      glyphPtr[4] | glyphPtr[5] | glyphPtr[6] | glyphPtr[7];
+        if (mask) {
+            UBYTE position = 0;
+            BYTE bit      = 7;
+            while (bit-- >= 0) {
+                if (mask & (1 << bit)) {
+                    break;
+                }
+                ++position;
+            }
+            left = position;
+            position = 8;
+            bit      = 0;
+            while (bit++ < 8) {
+                if (mask & (1 << bit)) {
+                    break;
+                }
+                --position;
+            }
+            width = position - left;
+        }
+        draw_GlyphSpacing_vb[i] = width << 4 | left;
+    }
+}
+
 /**
  * Draw a glyph into the target buffer, filling only the set pixels with the desired pen. There are probably lots
  * of ways this can be optimised.
  */
-static void draw_ChunkyGlyphFGOnly(UBYTE *drawPtr, UWORD drawSpan, UBYTE charGlyph, UBYTE fgPen)
+static void draw_ChunkyGlyph(UBYTE *drawPtr, UWORD drawSpan, UBYTE charGlyph, UBYTE pen)
 {
     UBYTE *planarPtr = &draw_ScrollChars_vb[(UWORD)charGlyph << 3];
     for (UWORD row = 0; row < DRAW_MSG_CHAR_H; ++row) {
         UBYTE plane = *planarPtr++;
         if (plane & 128) {
-            drawPtr[0] = fgPen;
+            drawPtr[0] = pen;
         }
         if (plane & 64) {
-            drawPtr[1] = fgPen;
+            drawPtr[1] = pen;
         }
         if (plane & 32) {
-            drawPtr[2] = fgPen;
+            drawPtr[2] = pen;
         }
         if (plane & 16) {
-            drawPtr[3] = fgPen;
+            drawPtr[3] = pen;
         }
         if (plane & 8) {
-            drawPtr[4] = fgPen;
+            drawPtr[4] = pen;
         }
         if (plane & 4) {
-            drawPtr[5] = fgPen;
+            drawPtr[5] = pen;
         }
         if (plane & 2) {
-            drawPtr[6] = fgPen;
+            drawPtr[6] = pen;
         }
         if (plane & 1) {
-            drawPtr[7] = fgPen;
+            drawPtr[7] = pen;
         }
-        drawPtr += drawSpan;
-    }
-}
-
-/**
- * Draw a glyph into the target buffer, filling all pixels with either the foreground or background pen as required.
- * There are probably lots of ways this can be optimised.
- */
-static void draw_ChunkyGlyph(UBYTE *drawPtr, UWORD drawSpan, UBYTE charGlyph, UBYTE fgPen, UBYTE bgPen)
-{
-    UBYTE *planarPtr = &draw_ScrollChars_vb[(UWORD)charGlyph << 3];
-    for (UWORD row = 0; row < DRAW_MSG_CHAR_H; ++row) {
-        UBYTE plane = *planarPtr++;
-        drawPtr[0] = plane & 128 ? fgPen : bgPen;
-        drawPtr[1] = plane &  64 ? fgPen : bgPen;
-        drawPtr[2] = plane &  32 ? fgPen : bgPen;
-        drawPtr[3] = plane &  16 ? fgPen : bgPen;
-        drawPtr[4] = plane &   8 ? fgPen : bgPen;
-        drawPtr[5] = plane &   4 ? fgPen : bgPen;
-        drawPtr[6] = plane &   2 ? fgPen : bgPen;
-        drawPtr[7] = plane &   1 ? fgPen : bgPen;
         drawPtr += drawSpan;
     }
 }
 
 /**
  * Draw a length limited, null terminated string of fixed glyphs at a given coordinate, foreground only.
- */
-const char* Draw_ChunkyTextFGOnly(
-    UBYTE *drawPtr,
-    UWORD drawSpan,
-    UWORD maxLen,
-    const char *textPtr,
-    UWORD xPos,
-    UWORD yPos,
-    UBYTE fgPen
-) {
-    drawPtr += drawSpan * yPos + xPos;
-    UBYTE charGlyph;
-    while ( (charGlyph = (UBYTE)*textPtr++) && maxLen-- > 0 ) {
-        /* Skip over all non-printing or blank. Assume ECMA-94 Latin 1 8-bit for Amiga 3.x */
-        if ( (charGlyph > 0x20 && charGlyph < 0x7F) || charGlyph > 0xA0) {
-            draw_ChunkyGlyphFGOnly(drawPtr, drawSpan, charGlyph, fgPen);
-        }
-        drawPtr += DRAW_MSG_CHAR_W;
-    }
-    return charGlyph ? textPtr : (const char*)NULL;
-}
-
-/**
- * Draw a null terminated string of fixed glyphs at a given coordinate, foreground/background
  */
 const char* Draw_ChunkyText(
     UBYTE *drawPtr,
@@ -325,17 +317,42 @@ const char* Draw_ChunkyText(
     const char *textPtr,
     UWORD xPos,
     UWORD yPos,
-    UBYTE fgPen,
-    UBYTE bgPen
+    UBYTE pen
 ) {
     drawPtr += drawSpan * yPos + xPos;
     UBYTE charGlyph;
-    while ( (charGlyph = (UBYTE)*textPtr++) && maxLen-- > 0) {
-        /* Skip over non-printing only.  Assume ECMA-94 Latin 1 8-bit for Amiga 3.x */
-        if ( (charGlyph >= 0x20 && charGlyph < 0x7F) || charGlyph >= 0xA0) {
-            draw_ChunkyGlyph(drawPtr, drawSpan, charGlyph, fgPen, bgPen);
+    while ( (charGlyph = (UBYTE)*textPtr++) && maxLen-- > 0 ) {
+        /* Skip over all non-printing or blank. Assume ECMA-94 Latin 1 8-bit for Amiga 3.x */
+        if ( (charGlyph > 0x20 && charGlyph < 0x7F) || charGlyph > 0xA0) {
+            draw_ChunkyGlyph(drawPtr, drawSpan, charGlyph, pen);
         }
         drawPtr += DRAW_MSG_CHAR_W;
+    }
+    return charGlyph ? textPtr : (const char*)NULL;
+}
+
+/**
+ * Draw a length limited, null terminated string of fixed glyphs at a given coordinate, foreground only.
+ */
+const char* Draw_ChunkyTextProp(
+    UBYTE *drawPtr,
+    UWORD drawSpan,
+    UWORD maxLen,
+    const char *textPtr,
+    UWORD xPos,
+    UWORD yPos,
+    UBYTE pen
+) {
+    drawPtr += drawSpan * yPos + xPos;
+    UBYTE charGlyph;
+    while ( (charGlyph = (UBYTE)*textPtr++) && maxLen-- > 0 ) {
+        UBYTE glyphSpacing = draw_GlyphSpacing_vb[charGlyph];
+        /* Skip over all non-printing or blank. Assume ECMA-94 Latin 1 8-bit for Amiga 3.x */
+        if ( (charGlyph > 0x20 && charGlyph < 0x7F) || charGlyph > 0xA0) {
+            draw_ChunkyGlyph(drawPtr - (glyphSpacing & 0xF), drawSpan, charGlyph, pen);
+        }
+        //drawPtr += DRAW_MSG_CHAR_W;
+        drawPtr += glyphSpacing >> 4;
     }
     return charGlyph ? textPtr : (const char*)NULL;
 }

--- a/ab3d2_source/c/draw.c
+++ b/ab3d2_source/c/draw.c
@@ -28,6 +28,9 @@ extern const UBYTE draw_BorderPacked_vb[];
 extern UBYTE draw_BorderChars_vb[];
 static UBYTE draw_Border[SCREEN_WIDTH * SCREEN_HEIGHT];
 
+/* These are the fixed with planar glyphs used for in-game messages */
+extern UBYTE draw_ScrollChars_vb[];
+
 /* Values used to track changes to the counters */
 extern UWORD draw_DisplayEnergyCount_w;
 extern UWORD draw_DisplayAmmoCount_w;

--- a/ab3d2_source/c/draw.h
+++ b/ab3d2_source/c/draw.h
@@ -56,16 +56,6 @@ extern void Draw_UpdateBorder_Planar(void);
  *
  * Returns a pointer to the next character to render, or null, if the end of the string was reached.
  */
-extern const char* Draw_ChunkyTextFGOnly(
-    UBYTE *drawPtr,
-    UWORD drawSpan,
-    UWORD maxLen,
-    const char *textPtr,
-    UWORD xPos,
-    UWORD yPos,
-    UBYTE fgPen
-);
-
 extern const char* Draw_ChunkyText(
     UBYTE *drawPtr,
     UWORD drawSpan,
@@ -73,8 +63,17 @@ extern const char* Draw_ChunkyText(
     const char *textPtr,
     UWORD xPos,
     UWORD yPos,
-    UBYTE fgPen,
-    UBYTE bgPen
+    UBYTE pen
+);
+
+extern const char* Draw_ChunkyTextProp(
+    UBYTE *drawPtr,
+    UWORD drawSpan,
+    UWORD maxLen,
+    const char *textPtr,
+    UWORD xPos,
+    UWORD yPos,
+    UBYTE pen
 );
 
 extern UBYTE *Vid_FastBufferPtr_l;

--- a/ab3d2_source/c/draw.h
+++ b/ab3d2_source/c/draw.h
@@ -16,6 +16,10 @@
 #define DRAW_HUD_ITEM_SLOTS_X 24
 #define DRAW_HUD_ITEM_SLOTS_Y -16
 
+/* These define the size of characters used in in game message display */
+#define DRAW_MSG_CHAR_W 8
+#define DRAW_MSG_CHAR_H 8
+
 
 /* These define the size of the digits used in the ammo/energy display */
 #define DRAW_HUD_CHAR_W 8
@@ -38,6 +42,10 @@ extern BOOL Draw_Init(void);
 extern void Draw_Shutdown(void);
 extern void Draw_UpdateBorder_RTG(APTR bmHandle, ULONG bmBytesPerRow);
 extern void Draw_UpdateBorder_Planar(void);
+
+/* These functions allow plotting the fixed text characters to a chunky buffer */
+extern void Draw_ChunkyTextFGOnly(UBYTE *drawPtr, UWORD drawSpan, const char *text, UWORD xPos, UWORD yPos, UBYTE fgPen);
+extern void Draw_ChunkyText(UBYTE *drawPtr, UWORD drawSpan, const char *text, UWORD xPos, UWORD yPos, UBYTE fgPen, UBYTE bgPen);
 
 extern UBYTE *Vid_FastBufferPtr_l;
 

--- a/ab3d2_source/c/draw.h
+++ b/ab3d2_source/c/draw.h
@@ -20,7 +20,6 @@
 #define DRAW_MSG_CHAR_W 8
 #define DRAW_MSG_CHAR_H 8
 
-
 /* These define the size of the digits used in the ammo/energy display */
 #define DRAW_HUD_CHAR_W 8
 #define DRAW_HUD_CHAR_H 7
@@ -43,9 +42,40 @@ extern void Draw_Shutdown(void);
 extern void Draw_UpdateBorder_RTG(APTR bmHandle, ULONG bmBytesPerRow);
 extern void Draw_UpdateBorder_Planar(void);
 
-/* These functions allow plotting the fixed text characters to a chunky buffer */
-extern void Draw_ChunkyTextFGOnly(UBYTE *drawPtr, UWORD drawSpan, const char *text, UWORD xPos, UWORD yPos, UBYTE fgPen);
-extern void Draw_ChunkyText(UBYTE *drawPtr, UWORD drawSpan, const char *text, UWORD xPos, UWORD yPos, UBYTE fgPen, UBYTE bgPen);
+/**
+ * These functions allow plotting the fixed text characters to a chunky buffer
+ *
+ * drawPtr  points to destination chunky buffer.
+ * drawSpan defines the distance, in pixels, from one row of the chunky buffer to the next.
+ * maxLen   defines the maximum number of characters to draw.
+ * textPtr  ppoints to the string of text to draw. Will render up to maxLen characters or the first NULL byte.
+ * xPos     defines the starting x coordinate in the chunky buffer
+ * yPos     defines the starting y coordinate in the chunky buffer
+ * fgPen    defines the palette index of the text rendering colour.
+ * bgPen    defines the palette index of the background rendering colour (when using background).
+ *
+ * Returns a pointer to the next character to render, or null, if the end of the string was reached.
+ */
+extern const char* Draw_ChunkyTextFGOnly(
+    UBYTE *drawPtr,
+    UWORD drawSpan,
+    UWORD maxLen,
+    const char *textPtr,
+    UWORD xPos,
+    UWORD yPos,
+    UBYTE fgPen
+);
+
+extern const char* Draw_ChunkyText(
+    UBYTE *drawPtr,
+    UWORD drawSpan,
+    UWORD maxLen,
+    const char *textPtr,
+    UWORD xPos,
+    UWORD yPos,
+    UBYTE fgPen,
+    UBYTE bgPen
+);
 
 extern UBYTE *Vid_FastBufferPtr_l;
 

--- a/ab3d2_source/c/draw.h
+++ b/ab3d2_source/c/draw.h
@@ -76,6 +76,12 @@ extern const char* Draw_ChunkyTextProp(
     UBYTE pen
 );
 
+/**
+ * Calculate the expected pixel width of the provided string (up to the maximum lenght provided) based on proportional
+ * size information.
+ */
+extern ULONG Draw_CalcPropWidth(const char *textPtr, UWORD maxLen);
+
 extern UBYTE *Vid_FastBufferPtr_l;
 
 #endif // DRAW_H

--- a/ab3d2_source/c/screen.c
+++ b/ab3d2_source/c/screen.c
@@ -388,8 +388,8 @@ static void CopyFrameBuffer(UBYTE *dst, const UBYTE *src, WORD dstBytesPerRow, W
 
 void Vid_Present()
 {
-
-    /* Draw_ChunkyTextFGOnly(Vid_FastBufferPtr_l, SCREEN_WIDTH, 39, "Test text render...", 4, 4, 255); */
+    //Draw_ChunkyTextProp(Vid_FastBufferPtr_l, SCREEN_WIDTH, 80, "This is an example of proportional rendering!", 4, 4, 255);
+    //Draw_ChunkyTextProp(Vid_FastBufferPtr_l, SCREEN_WIDTH, 80, "0123456789!\"$%^&*(){}[]|_+.,:;#@", 4, 12, 255);
 
     if (Vid_isRTG) {
         LOCAL_CYBERGFX();

--- a/ab3d2_source/c/screen.c
+++ b/ab3d2_source/c/screen.c
@@ -386,6 +386,10 @@ extern void Draw_UpdateBorder_RTG(APTR bmBaseAdress, ULONG bmBytesPerRow);
 
 void Vid_Present()
 {
+    Draw_ChunkyTextFGOnly(Vid_FastBufferPtr_l, SCREEN_WIDTH, "Draw_ChunkyTextFGOnly()", 10, 8, 255);
+    Draw_ChunkyText(Vid_FastBufferPtr_l, SCREEN_WIDTH, "Draw_ChunkyText()", 10, 16, 255, 0);
+
+
     if (Vid_isRTG) {
         LOCAL_CYBERGFX();
 

--- a/ab3d2_source/c/screen.c
+++ b/ab3d2_source/c/screen.c
@@ -43,6 +43,8 @@ static struct UCopList* doubleHeightCopList;
 extern UBYTE Vid_FullScreen_b;
 extern UWORD Vid_LetterBoxMarginHeight_w;
 
+extern void Draw_UpdateBorder_RTG(APTR bmBaseAdress, ULONG bmBytesPerRow);
+
 WORD Vid_ScreenHeight;
 WORD Vid_ScreenWidth;
 
@@ -382,13 +384,12 @@ static void CopyFrameBuffer(UBYTE *dst, const UBYTE *src, WORD dstBytesPerRow, W
     }
 }
 
-extern void Draw_UpdateBorder_RTG(APTR bmBaseAdress, ULONG bmBytesPerRow);
+
 
 void Vid_Present()
 {
-    Draw_ChunkyTextFGOnly(Vid_FastBufferPtr_l, SCREEN_WIDTH, "Draw_ChunkyTextFGOnly()", 10, 8, 255);
-    Draw_ChunkyText(Vid_FastBufferPtr_l, SCREEN_WIDTH, "Draw_ChunkyText()", 10, 16, 255, 0);
 
+    /* Draw_ChunkyTextFGOnly(Vid_FastBufferPtr_l, SCREEN_WIDTH, 39, "Test text render...", 4, 4, 255); */
 
     if (Vid_isRTG) {
         LOCAL_CYBERGFX();

--- a/ab3d2_source/c/screen.h
+++ b/ab3d2_source/c/screen.h
@@ -5,6 +5,7 @@
 
 #define SCREEN_WIDTH (UWORD)320
 #define SCREEN_HEIGHT (UWORD)256
+#define SCREEN_DEPTH 8
 
 /**
  * Define RTG_LONG_ALIGNED if you expect to perform 32-bit access to VRAM only

--- a/ab3d2_source/data/draw_data.s
+++ b/ab3d2_source/data/draw_data.s
@@ -26,6 +26,7 @@ CHARWIDTHS1:
 ENDFONT2:
 CHARWIDTHS2:
 
+_draw_FontPtrs_vl::
 draw_FontPtrs_vl:
 				dc.l	draw_EndFont0_vb,draw_CharWidths0_vb
 				dc.l	ENDFONT1,CHARWIDTHS1
@@ -37,6 +38,7 @@ draw_BorderChars_vb:
 				incbin	"includes/bordercharsraw"
 
 				align 4
+_draw_ScrollChars_vb::
 draw_ScrollChars_vb:
 				incbin	"includes/scrollfont"
 

--- a/ab3d2_source/data/draw_data.s
+++ b/ab3d2_source/data/draw_data.s
@@ -28,7 +28,8 @@ CHARWIDTHS2:
 
 _draw_FontPtrs_vl::
 draw_FontPtrs_vl:
-				dc.l	draw_EndFont0_vb,draw_CharWidths0_vb
+				dc.l	draw_EndFont0_vb
+				dc.l	draw_CharWidths0_vb
 				dc.l	ENDFONT1,CHARWIDTHS1
 				dc.l	ENDFONT2,CHARWIDTHS2
 

--- a/ab3d2_source/hires.s
+++ b/ab3d2_source/hires.s
@@ -7887,11 +7887,11 @@ Game_PushMessage:
 				move.l	a1,game_LastMessagePtr_l
 
 intosend:
-				move.l	d0,SCROLLPOINTER
-				move.w	#0,SCROLLXPOS
+				move.l	d0,draw_GameMessagePtr_l
+				move.w	#0,draw_GameMessageXPos_w
 				add.l	#160,d0
-				move.l	d0,ENDSCROLL
-				move.w	#40,SCROLLTIMER
+				move.l	d0,draw_GameMessageEnd_l
+				move.w	#40,draw_GameMessageTimer_w
 				move.l	(a7)+,a1
 				rts
 
@@ -7907,11 +7907,11 @@ Game_PullLastMessage:
 				move.l	-(a1),d0
 				beq.s	.nomessage
 
-				move.l	d0,SCROLLPOINTER
-				move.w	#0,SCROLLXPOS
+				move.l	d0,draw_GameMessagePtr_l
+				move.w	#0,draw_GameMessageXPos_w
 				add.l	#160,d0
-				move.l	d0,ENDSCROLL
-				move.w	#40,SCROLLTIMER
+				move.l	d0,draw_GameMessageEnd_l
+				move.w	#40,draw_GameMessageTimer_w
 
 				move.l	a1,game_LastMessagePtr_l
 
@@ -7920,10 +7920,8 @@ Game_PullLastMessage:
 
 				rts
 
-Game_MessageBuffer_vl:
-				ds.l	20
+Game_MessageBuffer_vl:	ds.l	20
 Game_MessageBufferEnd:
-
 game_MessagePtr_l:		dc.l	Game_MessageBuffer_vl
 game_LastMessagePtr_l:	dc.l	Game_MessageBuffer_vl
 
@@ -10181,24 +10179,20 @@ GLF_DatabasePtr_l:		dc.l	0
 
 hitcol:			dc.l	0
 
-SCROLLOFFSET:	dc.w	0
-SCROLLTIMER:	dc.w	100
-SCROLLDIRECTION: dc.w	1
-SCROLLXPOS:		dc.w	0
-SCROLLPOINTER:	dc.l	testscroll
-ENDSCROLL:		dc.l	endtestscroll
+draw_GameMessageTimer_w:	dc.w	100
+draw_GameMessageXPos_w:		dc.w	0
+draw_GameMessagePtr_l:		dc.l	draw_BlankMessage_vb
+draw_GameMessageEnd_l:		dc.l	draw_EndBlankMessage
 
-testscroll:
-;      12345678901234567890123456789012345678901234567890123456789012345678901234567890
-; dc.b "The Quick Brown Fox Jumped Over The Lazy Dog!                                   "
-; dc.b "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ                            "
-; dc.b "The Quick Brown Fox Jumped Over The Lazy Dog!                                   "
-
-BLANKSCROLL:
+draw_BlankMessage_vb:
+				;      12345678901234567890123456789012345678901234567890123456789012345678901234567890
+				; dc.b "The Quick Brown Fox Jumped Over The Lazy Dog!                                   "
+				; dc.b "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ                            "
+				; dc.b "The Quick Brown Fox Jumped Over The Lazy Dog!                                   "
 				dc.b	"                                                                                "
-endtestscroll:
+draw_EndBlankMessage:
 
-Vid_TextScreenPtr_l:		dc.l	0
+Vid_TextScreenPtr_l:	dc.l	0
 
 
 				SECTION	.bsschip,bss_c

--- a/ab3d2_source/hires.s
+++ b/ab3d2_source/hires.s
@@ -7922,6 +7922,7 @@ Game_PullLastMessage:
 
 Game_MessageBuffer_vl:	ds.l	20
 Game_MessageBufferEnd:
+_game_MessagePtr_l::
 game_MessagePtr_l:		dc.l	Game_MessageBuffer_vl
 game_LastMessagePtr_l:	dc.l	Game_MessageBuffer_vl
 
@@ -10179,18 +10180,22 @@ GLF_DatabasePtr_l:		dc.l	0
 
 hitcol:			dc.l	0
 
-draw_GameMessageTimer_w:	dc.w	100
+;draw_GameMessageTimer_w:	dc.w	100
+draw_GameMessageTimer_w:	dc.w	400
+
 draw_GameMessageXPos_w:		dc.w	0
+_draw_GameMessagePtr_l::
 draw_GameMessagePtr_l:		dc.l	draw_BlankMessage_vb
 draw_GameMessageEnd_l:		dc.l	draw_EndBlankMessage
 
+_draw_MessageBuffer_vb::
 draw_BlankMessage_vb:
-				;      12345678901234567890123456789012345678901234567890123456789012345678901234567890
+				;       12345678901234567890123456789012345678901234567890123456789012345678901234567890
 				; dc.b "The Quick Brown Fox Jumped Over The Lazy Dog!                                   "
 				; dc.b "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ                            "
 				; dc.b "The Quick Brown Fox Jumped Over The Lazy Dog!                                   "
 				dc.b	"                                                                                "
-draw_EndBlankMessage:
+draw_EndBlankMessage: dc.l    0
 
 Vid_TextScreenPtr_l:	dc.l	0
 

--- a/ab3d2_source/hires.s
+++ b/ab3d2_source/hires.s
@@ -223,19 +223,19 @@ Game_SlavePaused_b:			dc.b	0
 
 				align 4
 Game_ShowIntroText:
-				move.l	Lvl_IntroTextPtr_l,a0
-				move.w	PLOPT,d0
-				muls	#82*16,d0
-				add.l	d0,a0
-				move.w	#15,d7
-				move.w	#0,d0
+				move.l	Lvl_IntroTextPtr_l,a0     ; Pointer to main narrative text
+				move.w	PLOPT,d0                  ; Level number
+				muls	#82*16,d0                 ; Fixed size of 82 chars per line, 16 lines ?
+				add.l	d0,a0                     ; offset into narrative
+				move.w	#15,d7                    ; line counter
+				move.w	#0,d0                     ; line number
 
 .next_line_loop:
-				move.l	Vid_TextScreenPtr_l,a1
-				CALLC	Draw_LineOfText
+				move.l	Vid_TextScreenPtr_l,a1    ; Planar slice ptr
+				CALLC	Draw_LineOfText           ;
 
-				addq	#1,d0
-				add.w	#82,a0
+				addq	#1,d0                     ; increment line number
+				add.w	#82,a0                    ; next line of text
 				dbra	d7,.next_line_loop
 				rts
 

--- a/ab3d2_source/modules/draw.s
+++ b/ab3d2_source/modules/draw.s
@@ -319,7 +319,7 @@ Draw_NarrateText:
 				bra		.NOCHARYET
 
 .okcha:
-				; FIMXE: need to redirect this to teh actual screen
+				; FIMXE: need to redirect this to the actual screen
 				move.l	#SCROLLSCRN,a0
 				add.w	SCROLLXPOS,a0
 
@@ -339,9 +339,10 @@ Draw_NarrateText:
 				move.l	a1,SCROLLPOINTER
 
 				move.l	#draw_ScrollChars_vb,a1
-				asl.w	#3,d1
-				add.w	d1,a1
+				asl.w	#3,d1  ; each character glyph is 8 bytes
+				add.w	d1,a1  ; address of character glyph
 
+				; render into planes
 				move.b	(a1)+,(a0)
 				move.b	(a1)+,80(a0)
 				move.b	(a1)+,80*2(a0)
@@ -351,7 +352,7 @@ Draw_NarrateText:
 				move.b	(a1)+,80*6(a0)
 				move.b	(a1)+,80*7(a0)
 
-				addq	#1,a0
+				addq	#1,a0 ; advance a character position
 				dbra	d7,.doachar
 
 				move.w	SCROLLXPOS,d0

--- a/ab3d2_source/modules/draw.s
+++ b/ab3d2_source/modules/draw.s
@@ -307,37 +307,35 @@ Draw_NarrateText:
 ;				swap	d1
 ;				move.w	d1,scrolh
 
-				move.w	SCROLLTIMER,d0
+				move.w	draw_GameMessageTimer_w,d0
 				subq	#1,d0
-				move.w	d0,SCROLLTIMER
+				move.w	d0,draw_GameMessageTimer_w
 				cmp.w	#40,d0
 				bge		.NOCHARYET
 				tst.w	d0
 				bge.s	.okcha
 
-				move.w	#150,SCROLLTIMER
+				move.w	#150,draw_GameMessageTimer_w
 				bra		.NOCHARYET
 
 .okcha:
 				; FIMXE: need to redirect this to the actual screen
 				move.l	#SCROLLSCRN,a0
-				add.w	SCROLLXPOS,a0
-
+				add.w	draw_GameMessageXPos_w,a0
 				moveq	#1,d7
-.doachar:
 
-				move.l	SCROLLPOINTER,a1
+.doachar:
+				move.l	draw_GameMessagePtr_l,a1
 				moveq	#0,d1
 				move.b	(a1)+,d1				; character
 				move.l	a1,d2
-				cmp.l	ENDSCROLL,d2
+				cmp.l	draw_GameMessageEnd_l,d2
 				blt.s	.notrestartscroll
-				move.l	#BLANKSCROLL,a1
-				move.l	#BLANKSCROLL+80,ENDSCROLL
+				move.l	#draw_BlankMessage_vb,a1
+				move.l	#draw_BlankMessage_vb+80,draw_GameMessageEnd_l
 
 .notrestartscroll:
-				move.l	a1,SCROLLPOINTER
-
+				move.l	a1,draw_GameMessagePtr_l
 				move.l	#draw_ScrollChars_vb,a1
 				asl.w	#3,d1  ; each character glyph is 8 bytes
 				add.w	d1,a1  ; address of character glyph
@@ -355,12 +353,13 @@ Draw_NarrateText:
 				addq	#1,a0 ; advance a character position
 				dbra	d7,.doachar
 
-				move.w	SCROLLXPOS,d0
+				move.w	draw_GameMessageXPos_w,d0
 				addq	#2,d0
-				move.w	d0,SCROLLXPOS
+				move.w	d0,draw_GameMessageXPos_w
 				cmp.w	#80,d0
 				blt		.NOCHARYET
-				move.w	#0,SCROLLXPOS
+
+				move.w	#0,draw_GameMessageXPos_w
 
 .NOCHARYET:
 				rts

--- a/ab3d2_source/modules/draw.s
+++ b/ab3d2_source/modules/draw.s
@@ -315,7 +315,7 @@ Draw_NarrateText:
 				tst.w	d0
 				bge.s	.okcha
 
-				move.w	#150,draw_GameMessageTimer_w
+				move.w	#500,draw_GameMessageTimer_w
 				bra		.NOCHARYET
 
 .okcha:

--- a/ab3d2_source/modules/draw.s
+++ b/ab3d2_source/modules/draw.s
@@ -51,7 +51,14 @@ Draw_ResetGameDisplay:
 ;*
 ;* This renders a line of text to the planar screen.
 ;*
-;* Deprecated for RTG
+;* Deprecated for RTG. Called only from the level intro text loop
+;*
+;* Deduced parameters
+;*   a0 text address (80 chars), with 2 byte header:
+;*      - Byte 0 is the font selection from #draw_FontPtrs_vl (only 0 used)
+;*      - Byte 1 indicates justification (0 none, 1 centred)
+;*   a1 planar screen ptr
+;*   d0 is line number (0-15)
 ;*
 ;******************************************************************************
 Draw_LineOfText:
@@ -60,27 +67,27 @@ Draw_LineOfText:
 				add.l	d0,a1					; screen pointer
 				move.l	#draw_FontPtrs_vl,a3
 				moveq	#0,d0
-				move.b	(a0)+,d0
-				move.l	(a3,d0.w*8),a2
-				move.l	4(a3,d0.w*8),a3
+				move.b	(a0)+,d0                ; first text byte in d0 is...
+				move.l	(a3,d0.w*8),a2          ; Font Glyph poined to by a2
+				move.l	4(a3,d0.w*8),a3         ; Char width pointed to in a3
 				moveq	#0,d4
-				moveq	#0,d1					; width counter:
-				move.w	#79,d6
-				tst.b	(a0)+
+				moveq	#0,d1                   ; width counter:
+				move.w	#79,d6                  ; number of characters
+				tst.b	(a0)+                   ; second text byte is justification
 				beq.s	.not_centred
 
 				moveq	#-1,d5
-				move.l	a0,a4
+				move.l	a0,a4                   ; actual string in a4 now
 				moveq	#0,d2
-				moveq	#0,d3
-				move.w	#79,d0					; number of chars
+				moveq	#0,d3                   ; total width in pixels
+				move.w	#79,d0                  ; number of chars
 
 .addup:
 				addq	#1,d5
-				move.b	(a4)+,d2
-				move.b	-32(a3,d2.w),d4
-				add.w	d4,d3
-				cmp.b	#32,d2
+				move.b	(a4)+,d2                ; next char in d2
+				move.b	-32(a3,d2.w),d4         ; width of char in d4 (no widths for non-printing 0-31)
+				add.w	d4,d3                   ; sum width
+				cmp.b	#32,d2                  ; don't include space character in width calculation
 				beq.s	.dont_put_in
 
 				move.w	d5,d6
@@ -88,29 +95,29 @@ Draw_LineOfText:
 
 .dont_put_in:
 				dbra	d0,.addup
-				asr.w	#1,d1
+				asr.w	#1,d1                   ; Calculate x coordinate for centred string
 				neg.w	d1
-				add.w	#SCREEN_WIDTH,d1			; horiz pos of start x
+				add.w	#SCREEN_WIDTH,d1        ; horiz pos of start x
 
 .not_centred:
 				move.w	d6,d7
 
 .do_char:
 				moveq	#0,d2
-				move.b	(a0)+,d2
-				sub.w	#32,d2
+				move.b	(a0)+,d2                 ; char code in d2
+				sub.w	#32,d2                   ; -32 for glyph index
 				moveq	#0,d6
-				move.b	(a3,d2.w),d6
-				asl.w	#5,d2
-				lea		(a2,d2.w),a4			; char font
+				move.b	(a3,d2.w),d6             ; glyph width in d6
+				asl.w	#5,d2                    ;
+				lea		(a2,d2.w),a4			 ; glyph data ptr is a4 + 32*glyph index
 val				SET		0
-				REPT	16
-				move.w	(a4)+,d0
-				bfins	d0,val(a1){d1:d6}
-val				SET		val+80
+				REPT	16                       ; glyph bitmap is 16 pixels tall (?)
+				move.w	(a4)+,d0                 ; glyph bitmap is 16 pixels wide
+				bfins	d0,val(a1){d1:d6}        ; use bitfield insertion, d1 contains x position, d6 with
+val				SET		val+80                   ; next span
 				ENDR
-				add.w	d6,d1
-				dbra	d7,.do_char
+				add.w	d6,d1                    ; increment x offset by width
+				dbra	d7,.do_char              ; rinse and repeat.
 				movem.l	(a7)+,d0/a0/d7
 				rts
 

--- a/ab3d2_source/pauseopts.s
+++ b/ab3d2_source/pauseopts.s
@@ -1,9 +1,9 @@
 				align 4
 Game_Pause:
-				move.l	#PAUSETEXT,SCROLLPOINTER
-				move.l	#ENDPAUSETEXT,ENDSCROLL
-				move.w	#0,SCROLLXPOS
-				move.w	#40,SCROLLTIMER
+				move.l	#PAUSETEXT,draw_GameMessagePtr_l
+				move.l	#ENDPAUSETEXT,draw_GameMessageEnd_l
+				move.w	#0,draw_GameMessageXPos_w
+				move.w	#40,draw_GameMessageTimer_w
 				move.w	#40,d6
 .waitpause:
 				jsr		Draw_NarrateText
@@ -54,10 +54,10 @@ Game_Pause:
 				btst	#7,$bfe001
 				beq.s	.wr2
 
-				move.l	#BLANKSCROLL,SCROLLPOINTER
-				move.l	#BLANKSCROLL+80,ENDSCROLL
-				move.w	#0,SCROLLXPOS
-				move.w	#40,SCROLLTIMER
+				move.l	#draw_BlankMessage_vb,draw_GameMessagePtr_l
+				move.l	#draw_BlankMessage_vb+80,draw_GameMessageEnd_l
+				move.w	#0,draw_GameMessageXPos_w
+				move.w	#40,draw_GameMessageTimer_w
 				move.w	#40,d6
 
 .waitpause2:


### PR DESCRIPTION
Adds C functions for rendering chunky text using the existing embedded fixed with font:

Draw_ChunkyText() renders text over an existing buffer.
Draw_ChunkyTextProp() renders text over an existing buffer proportionally.

Both functions can render to either a fast memory buffer, or a locked chunky BitMap, though the latter is expected to be slower since plotting is one pixel at a time. The functions accept a maximum char count but will stop rendering if a null byte is encountered. The functions return the address of the next character or null if the string reached a null terminator.

The system scans the 8x8 font and determines the character spacing information directly, with a couple of tweaks for 'r' and 't' which seem to end up with a little too much left hand space.

There are some other small changes that relate to tidying and experimentation, but nothing major or breaking.
![propfont2](https://github.com/mheyer32/alienbreed3d2/assets/27722116/4763c8b2-55ab-41ae-a8f5-8310e5807a0b)
