### PR TITLE
Disable 2 player modes only when misc.resource is unavailable (C/RTG)

### DIFF
--- a/ab3d2_source/c/system.c
+++ b/ab3d2_source/c/system.c
@@ -141,6 +141,10 @@ BOOL Sys_OpenLibs(void)
         goto fail;
     }
 
+    if (!(PotgoBase = OpenResource(POTGONAME))) {
+        goto fail;
+    }
+
     {
         /* Set up the (software)interrupt structure. Note that this task runs at  */
         /* priority 0. Software interrupts may only be priority -32, -16, 0, +16, */

--- a/ab3d2_source/controlloop.s
+++ b/ab3d2_source/controlloop.s
@@ -108,15 +108,19 @@ BACKTOMENU:
 
 				cmp.b	#PLR_SLAVE,Plr_MultiplayerType_b
 				beq.s	BACKTOSLAVE
+
 				cmp.b	#PLR_MASTER,Plr_MultiplayerType_b
 				beq.s	BACKTOMASTER
 				bsr		READMAINMENU
 				bra		DONEMENU
+
 BACKTOMASTER:
 				bsr		MASTERMENU
 				bra		DONEMENU
+
 BACKTOSLAVE:
 				bsr		SLAVEMENU
+
 DONEMENU:
 				tst.b	SHOULDQUIT
 				bne		QUITTT
@@ -187,7 +191,6 @@ DONEMENU:
 
 dontusestats:
 				CALLC	mnu_setscreen
-
 
 				bra		BACKTOMENU
 
@@ -599,7 +602,11 @@ GETACHAR:
 
 
 MASTERMENU:
+				tst.l	_MiscResourceBase
+				bne.s	.ok_master
+				rts
 
+.ok_master:
 				move.b	#PLR_MASTER,Plr_MultiplayerType_b
 
 				move.w	#0,LEVELSELECTED
@@ -673,6 +680,11 @@ MASTERMENU:
 				rts
 
 SLAVEMENU:
+				tst.l	_MiscResourceBase
+				bne.s	.ok_master
+				rts
+
+.ok_master:
 
 				move.b	#PLR_SLAVE,Plr_MultiplayerType_b
 


### PR DESCRIPTION
C/RTG build: Disabled multiplayer options when misc.resource is not available, allowing the single player mode to be used still.