### PR TITLE
clr screenmsgbuffer when exiting a level

### DIFF
--- a/ab3d2_source/hires.s
+++ b/ab3d2_source/hires.s
@@ -471,8 +471,9 @@ noclips:
 ; move.l #Blurbfield,$dff080
 
 				IFD BUILD_WITH_C
-				tst.w	_Vid_isRTG
-				bne.s	.skipChangeScreen
+				;tst.w	_Vid_isRTG
+				;bne.s	.skipChangeScreen
+				bra.s .skipChangeScreen
 				ENDIF
 
 				IFNE	DISPLAYMSGPORT_HACK
@@ -8750,6 +8751,19 @@ closeeverything:
 ;.noPotgoResource
 ;
 ;				move.l	#0,d0					; FIXME indicate failure
+
+				IFNE	DISPLAYMSGPORT_HACK
+				;empty Vid_DisplayMsgPort_l and set Vid_ScreenBufferIndex_w to 0
+				;so the starting point is the same every time
+.clrMsgPort:
+				move.l	Vid_DisplayMsgPort_l,a0
+				CALLEXEC GetMsg
+				tst.l	d0
+				bne.s	.clrMsgPort
+				ENDC
+
+				clr.w	Vid_ScreenBufferIndex_w
+
 				rts
 
 

--- a/ab3d2_source/hires.s
+++ b/ab3d2_source/hires.s
@@ -8752,6 +8752,11 @@ closeeverything:
 ;
 ;				move.l	#0,d0					; FIXME indicate failure
 
+				IFD BUILD_WITH_C
+				tst.w	_Vid_isRTG
+				bne.s	.skipClear
+				ENDIF
+				
 				IFNE	DISPLAYMSGPORT_HACK
 				;empty Vid_DisplayMsgPort_l and set Vid_ScreenBufferIndex_w to 0
 				;so the starting point is the same every time
@@ -8763,7 +8768,7 @@ closeeverything:
 				ENDC
 
 				clr.w	Vid_ScreenBufferIndex_w
-
+.skipClear
 				rts
 
 


### PR DESCRIPTION
a work around for the AGA screen modes having lockups @50fps when restarting a level.
wait for feed back from EAB.