### PR TITLE
Build/cpu targets

### DIFF
--- a/ab3d2_source/Makefile
+++ b/ab3d2_source/Makefile
@@ -10,10 +10,11 @@ PREFIX = $(shell ./getprefix.sh "$(CC)")
 
 #-DCD32VER
 
-CFLAGS = -m68020-60 -mtune=68030 -noixemul -g -ggdb -O3
+CFLAGS = -noixemul -g -ggdb -O3
 LFLAGS = -noixemul -g -ggdb
 
-AFLAGS = -Fhunk -m68060 -linedebug -chklabels -align -L listing.txt -Dmnu_nocode=1 -DUSE_16X16_TEXEL_MULS -DOPT060
+# Allow 040+ instructions to be emitted in runtime detection cases
+AFLAGS = -Fhunk -m68060 -linedebug -chklabels -align -L listing.txt -Dmnu_nocode=1 -DUSE_16X16_TEXEL_MULS
 
 AFLAGS += -I../ \
 		  -I$(PREFIX)/m68k-amigaos/ndk-include \
@@ -24,9 +25,9 @@ AFLAGS += -I../ \
 
 VFLAGS = -b amigahunk -sc -l amiga -L $(PREFIX)m68k-amigaos/ndk/lib/libs
 
-all:	hires hiresC
+all:	tkg tkgC
 dev:	AFLAGS += -DDEV=1
-dev:	hires hiresC
+dev:	tkg tkgC
 
 OBJS = c/main.o \
 	   c/screen.o \
@@ -40,12 +41,41 @@ OBJS = c/main.o \
 	   c/game.o \
 	   c/hires.o
 
-hiresC: AFLAGS+=-DBUILD_WITH_C
-hiresC: ${OBJS}
+tkg: hires.o
+	$(VLINK) $(VFLAGS) $< -o $@
+
+tkgC: AFLAGS+=-DBUILD_WITH_C
+tkgC: CFLAGS+=-m68020-60 -mtune=68030
+tkgC: ${OBJS}
 		$(LINK) $(LFLAGS) $^ -ldebug -o $@
 
-hires: hires.o
+040:	tkg040 tkgC040
+040_dev:	AFLAGS += -DDEV=1
+040_dev:	tkg040 tkgC040
+
+
+tkg040: AFLAGS+=-DOPT040
+tkg040: hires.o
 	$(VLINK) $(VFLAGS) $< -o $@
+
+tkgC040: AFLAGS+=-DBUILD_WITH_C -DOPT040
+tkgC040: CFLAGS+=-m68040 -mtune=68040
+tkgC040: ${OBJS}
+		$(LINK) $(LFLAGS) $^ -ldebug -o $@
+
+060:	tkg060 tkgC060
+060_dev:	AFLAGS += -DDEV=1
+060_dev:	tkg060 tkgC060
+
+
+tkg060: AFLAGS+=-DOPT060
+tkg060: hires.o
+	$(VLINK) $(VFLAGS) $< -o $@
+
+tkgC060: AFLAGS+=-DBUILD_WITH_C -DOPT060
+tkgC060: CFLAGS+=-m68060 -mtune=68060
+tkgC060: ${OBJS}
+		$(LINK) $(LFLAGS) $^ -ldebug -o $@
 
 
 clean:

--- a/ab3d2_source/Makefile
+++ b/ab3d2_source/Makefile
@@ -10,8 +10,8 @@ PREFIX = $(shell ./getprefix.sh "$(CC)")
 
 #-DCD32VER
 
-CFLAGS = -noixemul -g -ggdb -O3
-LFLAGS = -noixemul -g -ggdb
+CFLAGS = -noixemul -O3
+LFLAGS = -noixemul
 
 # Allow 040+ instructions to be emitted in runtime detection cases
 AFLAGS = -Fhunk -m68060 -linedebug -chklabels -align -L listing.txt -Dmnu_nocode=1 -DUSE_16X16_TEXEL_MULS
@@ -25,9 +25,61 @@ AFLAGS += -I../ \
 
 VFLAGS = -b amigahunk -sc -l amiga -L $(PREFIX)m68k-amigaos/ndk/lib/libs
 
-all:	tkg tkgC
+# Generic dev builds - dev features, debugging on, unstripped
+dev:	tkg_dev tkgc_dev
 dev:	AFLAGS += -DDEV=1
-dev:	tkg tkgC
+dev:	CFLAGS += -m68020-60 -mtune=68030 -DDEV -g -ggdb
+dev:	LFLAGS += -g -ggdb
+
+# Generic test builds, release features, debugging on, unstripped
+test:	tkg_test tkgc_test
+test:	CFLAGS += -m68020-60 -mtune=68030 -g -ggdb
+test:	LFLAGS += -g -ggdb
+
+# Generic release builds, release features, debugging off, stripped
+rel:	tkg tkgc
+rel:	CFLAGS+=-m68020-60 -mtune=68030
+rel:
+	$(STRIP) --strip-debug --strip-unneeded tkg
+	$(STRIP) --strip-debug --strip-unneeded tkgc
+
+# 68040 tuned dev builds
+dev040:	tkg_dev_040 tkgc_dev_040
+dev040:	AFLAGS += -DDEV=1 -DOPT040
+dev040:	CFLAGS += -m68040 -mtune=68040 -DDEV -g -ggdb
+dev040:	LFLAGS += -g -ggdb
+
+# 68040 tuned test builds
+test040:	tkg_test_040 tkgc_test_040
+test040:	CFLAGS += -m68040 -mtune=68040 -g -ggdb
+test040:	LFLAGS += -g -ggdb
+
+# 68040 tuned release builds
+rel040:	tkg_040 tkgc_040
+rel040:	AFLAGS += -DOPT040
+rel040:	CFLAGS += -m68040 -mtune=68040
+rel040:
+	$(STRIP) --strip-debug --strip-unneeded tkg_040
+	$(STRIP) --strip-debug --strip-unneeded tkgc_040
+
+# 68060 tuned dev builds
+dev060:	tkg_dev_060 tkgc_dev_060
+dev060:	AFLAGS += -DDEV=1 -DOPT060
+dev060:	CFLAGS += -m68060 -mtune=68060 -DDEV -g -ggdb
+dev060:	LFLAGS += -g -ggdb
+
+# 68060 tuned test builds
+test060:	tkg_test_060 tkgc_test_060
+test060:	CFLAGS += -m68060 -mtune=68060 -g -ggdb
+test060:	LFLAGS += -g -ggdb
+
+# 68060 tuned release builds
+rel060:	tkg_060 tkgc_060
+rel060:	AFLAGS += -DOPT060
+rel060:	CFLAGS += -m68060 -mtune=68060
+rel060:
+	$(STRIP) --strip-debug --strip-unneeded tkg_060
+	$(STRIP) --strip-debug --strip-unneeded tkgc_060
 
 OBJS = c/main.o \
 	   c/screen.o \
@@ -41,41 +93,74 @@ OBJS = c/main.o \
 	   c/game.o \
 	   c/hires.o
 
+# GENERIC ##################################
+
+tkg_dev: hires.o
+	$(VLINK) $(VFLAGS) $< -o $@
+
+tkgc_dev:	AFLAGS+=-DBUILD_WITH_C
+tkgc_dev:	${OBJS}
+	$(LINK) $(LFLAGS) $^ -o $@
+
+tkg_test: hires.o
+	$(VLINK) $(VFLAGS) $< -o $@
+
+tkgc_test:	AFLAGS+=-DBUILD_WITH_C
+tkgc_test:	${OBJS}
+	$(LINK) $(LFLAGS) $^ -o $@
+
 tkg: hires.o
 	$(VLINK) $(VFLAGS) $< -o $@
 
-tkgC: AFLAGS+=-DBUILD_WITH_C
-tkgC: CFLAGS+=-m68020-60 -mtune=68030
-tkgC: ${OBJS}
-		$(LINK) $(LFLAGS) $^ -ldebug -o $@
+tkgc:	AFLAGS+=-DBUILD_WITH_C
+tkgc:	${OBJS}
+	$(LINK) $(LFLAGS) $^ -o $@
 
-040:	tkg040 tkgC040
-040_dev:	AFLAGS += -DDEV=1
-040_dev:	tkg040 tkgC040
+# 68040 ##################################
 
-
-tkg040: AFLAGS+=-DOPT040
-tkg040: hires.o
+tkg_dev_040: hires.o
 	$(VLINK) $(VFLAGS) $< -o $@
 
-tkgC040: AFLAGS+=-DBUILD_WITH_C -DOPT040
-tkgC040: CFLAGS+=-m68040 -mtune=68040
-tkgC040: ${OBJS}
-		$(LINK) $(LFLAGS) $^ -ldebug -o $@
+tkgc_dev_040:	AFLAGS+=-DBUILD_WITH_C
+tkgc_dev_040:	${OBJS}
+	$(LINK) $(LFLAGS) $^ -o $@
 
-060:	tkg060 tkgC060
-060_dev:	AFLAGS += -DDEV=1
-060_dev:	tkg060 tkgC060
-
-
-tkg060: AFLAGS+=-DOPT060
-tkg060: hires.o
+tkg_test_040: hires.o
 	$(VLINK) $(VFLAGS) $< -o $@
 
-tkgC060: AFLAGS+=-DBUILD_WITH_C -DOPT060
-tkgC060: CFLAGS+=-m68060 -mtune=68060
-tkgC060: ${OBJS}
-		$(LINK) $(LFLAGS) $^ -ldebug -o $@
+tkgc_test_040:	AFLAGS+=-DBUILD_WITH_C
+tkgc_test_040:	${OBJS}
+	$(LINK) $(LFLAGS) $^ -o $@
+
+tkg_040: hires.o
+	$(VLINK) $(VFLAGS) $< -o $@
+
+tkgc_040:	AFLAGS+=-DBUILD_WITH_C
+tkgc_040:	${OBJS}
+	$(LINK) $(LFLAGS) $^ -o $@
+
+# 68060 ##################################
+
+tkg_dev_060: hires.o
+	$(VLINK) $(VFLAGS) $< -o $@
+
+tkgc_dev_060:	AFLAGS+=-DBUILD_WITH_C
+tkgc_dev_060:	${OBJS}
+	$(LINK) $(LFLAGS) $^ -o $@
+
+tkg_test_060: hires.o
+	$(VLINK) $(VFLAGS) $< -o $@
+
+tkgc_test_060:	AFLAGS+=-DBUILD_WITH_C
+tkgc_test_060:	${OBJS}
+	$(LINK) $(LFLAGS) $^ -o $@
+
+tkg_060: hires.o
+	$(VLINK) $(VFLAGS) $< -o $@
+
+tkgc_060:	AFLAGS+=-DBUILD_WITH_C
+tkgc_060:	${OBJS}
+	$(LINK) $(LFLAGS) $^ -o $@
 
 
 clean:
@@ -84,7 +169,6 @@ clean:
 
 c/%.o: %.s Makefile
 	$(ASS) $(AFLAGS) $< -o $@
-
 
 %.o: %.s Makefile
 	$(ASS) $(AFLAGS) $< -o $@

--- a/ab3d2_source/Makefile
+++ b/ab3d2_source/Makefile
@@ -162,6 +162,7 @@ tkgc_060:	AFLAGS+=-DBUILD_WITH_C
 tkgc_060:	${OBJS}
 	$(LINK) $(LFLAGS) $^ -o $@
 
+#############################################################
 
 clean:
 	rm -f *.o

--- a/ab3d2_source/bss/game_bss.s
+++ b/ab3d2_source/bss/game_bss.s
@@ -6,15 +6,14 @@
 			align 4
 
 _Game_ProgressSignal::
-Game_ProgressSignal_l:	     ds.l 1 ; cleared at the start of every frame and checked at the end
+Game_ProgressSignal_l:			ds.l 1 ; cleared at the start of every frame and checked at the end
 
 _game_PlayerProgression::
-game_PlayerProgression:
-	ds.b GStatT_SizeOf_l ; see defs.i for structure
+game_PlayerProgression:			ds.b GStatT_SizeOf_l ; see defs.i for structure
 game_PlayerProgressionEnd:
 
 _game_AchievementsDataPtr::
-game_AchievementsDataPtr_l:     ds.l 1
+game_AchievementsDataPtr_l:		ds.l 1
 
 _game_BestLevelTimeBuffer::
-game_BestLevelTimeBuffer_vb:    ds.b LVLT_MESSAGE_LENGTH
+game_BestLevelTimeBuffer_vb:	ds.b LVLT_MESSAGE_LENGTH

--- a/ab3d2_source/bss/vid_bss.s
+++ b/ab3d2_source/bss/vid_bss.s
@@ -12,8 +12,12 @@
 ; BSS data - to be included in BSS section
 			align 4
 
-Vid_ChunkyFS1x1InitPtr_l:	ds.l	1
-Vid_ChunkyFS1x1ConvPtr_l:	ds.l	1
+Vid_ChunkyFS1x1InitPtr_l:		ds.l	1	; Points to 1x1 C2P Initialisation for Fullscreen
+Vid_ChunkyFS1x1ConvPtr_l:		ds.l	1	; Points to 1x1 C2P Conversion for Fullscreen
+
+;Vid_ChunkySmall1x1InitPtr_l:	ds.l	1	; Points to 1x1 C2P Initialisation for Small Screen
+;Vid_ChunkySmall1x1ConvPtr_l:	ds.l	1	; Points to 1x1 C2P Conersion for Small Screen
+
 
 _Vid_FastBufferPtr_l::
 Vid_FastBufferPtr_l:		ds.l	1	; aligned address

--- a/ab3d2_source/bss/vid_bss.s
+++ b/ab3d2_source/bss/vid_bss.s
@@ -12,6 +12,9 @@
 ; BSS data - to be included in BSS section
 			align 4
 
+Vid_ChunkyFS1x1InitPtr_l:	ds.l	1
+Vid_ChunkyFS1x1ConvPtr_l:	ds.l	1
+
 _Vid_FastBufferPtr_l::
 Vid_FastBufferPtr_l:		ds.l	1	; aligned address
 Vid_FastBufferAllocPtr_l:	ds.l	1	; allocated address

--- a/ab3d2_source/c/screen.c
+++ b/ab3d2_source/c/screen.c
@@ -52,6 +52,8 @@ WORD Vid_ScreenWidth;
 ULONG Vid_ScreenMode;
 BOOL Vid_isRTG;
 
+extern void Vid_InitC2P(void);
+
 void Vid_Present();
 void Vid_ConvertC2P();
 void Vid_CloseMainScreen();
@@ -63,6 +65,7 @@ void Vid_OpenMainScreen(void)
     LOCAL_GFX();
 
     if (!Vid_isRTG) {
+        CallAsm(&Vid_InitC2P);
         for (int i = 0; i < 2; ++i) {
             if (!(rasters[i] = AllocRaster(SCREEN_WIDTH, SCREEN_HEIGHT * 8 + 1))) {
                 Sys_FatalError("AllocRaster failed");

--- a/ab3d2_source/c2p1x1_8_c5_030_2.s
+++ b/ab3d2_source/c2p1x1_8_c5_030_2.s
@@ -1,0 +1,457 @@
+;
+; 2000-04-17
+;
+; c2p1x1_8_c5_030_2
+;
+; 1.22vbl [all dma off] on Bliz1230-IV@50
+;
+; 2000-04-17: added bplsize modifying init (smcinit)
+; 1999-01-08: initial version
+;
+; bplsize must be less than or equal to 16kB!
+;
+
+	IFND	BPLX
+BPLX	EQU	320
+	ENDC
+	IFND	BPLY
+BPLY	EQU	256
+	ENDC
+	IFND	BPLSIZE
+BPLSIZE	EQU	BPLX*BPLY/8
+	ENDC
+	IFND	CHUNKYXMAX
+CHUNKYXMAX EQU	BPLX
+	ENDC
+	IFND	CHUNKYYMAX
+CHUNKYYMAX EQU	BPLY
+	ENDC
+
+
+;	incdir	include:
+	include	lvo/exec_lib.i
+
+
+	section	code,code
+
+; d0.w	chunkyx [chunky-pixels]
+; d1.w	chunkyy [chunky-pixels]
+; d2.w	(scroffsx) [screen-pixels]
+; d3.w	scroffsy [screen-pixels]
+; d4.l	(rowlen) [bytes] -- offset between one row and the next in a bpl
+; d5.l	bplsize [bytes] -- offset between one row in one bpl and the next bpl
+; d6.l	(chunkylen) [bytes] -- offset between one row and the next in chunkybuf
+
+	XDEF	_c2p1x1_8_c5_030_2_smcinit
+	XDEF	c2p1x1_8_c5_030_2_smcinit
+_c2p1x1_8_c5_030_2_smcinit
+c2p1x1_8_c5_030_2_smcinit
+	movem.l	d2-d3/d5/a6,-(sp)
+	andi.l	#$ffff,d0
+	mulu.w	d0,d3
+	lsr.l	#3,d3
+	move.l	d3,c2p1x1_8_c5_030_2_scroffs
+	mulu.w	d0,d1
+	move.l	d1,c2p1x1_8_c5_030_2_pixels
+
+	move.w	d5,c2p1x1_8_c5_030_2_smc1
+	move.w	d5,c2p1x1_8_c5_030_2_smc2
+	move.w	d5,c2p1x1_8_c5_030_2_smc5
+	move.w	d5,c2p1x1_8_c5_030_2_smc8
+	move.w	d5,c2p1x1_8_c5_030_2_smc11
+
+	move.w	d5,d0
+	neg.w	d0
+	subq.w	#4,d0
+	move.w	d0,c2p1x1_8_c5_030_2_smc3
+	move.w	d0,c2p1x1_8_c5_030_2_smc6
+	move.w	d0,c2p1x1_8_c5_030_2_smc9
+	move.w	d0,c2p1x1_8_c5_030_2_smc12
+
+	add.l	d5,d5
+	move.w	d5,c2p1x1_8_c5_030_2_smc4
+	move.w	d5,c2p1x1_8_c5_030_2_smc10
+	add.l	d5,d5
+	move.l	d5,c2p1x1_8_c5_030_2_smc7
+
+	move.l	$4.w,a6
+	jsr	_LVOCacheClearU(a6)
+
+	movem.l	(sp)+,d2-d3/d5/a6
+	rts
+
+; d0.w	chunkyx [chunky-pixels]
+; d1.w	chunkyy [chunky-pixels]
+; d2.w	(scroffsx) [screen-pixels]
+; d3.w	scroffsy [screen-pixels]
+; d4.l	(rowlen) [bytes] -- offset between one row and the next in a bpl
+; d5.l	(bplsize) [bytes] -- offset between one row in one bpl and the next bpl
+; d6.l	(chunkylen) [bytes] -- offset between one row and the next in chunkybuf
+
+	XDEF	_c2p1x1_8_c5_030_2_init
+	XDEF	c2p1x1_8_c5_030_2_init
+_c2p1x1_8_c5_030_2_init
+c2p1x1_8_c5_030_2_init
+	movem.l	d2-d3,-(sp)
+	andi.l	#$ffff,d0
+	mulu.w	d0,d3
+	lsr.l	#3,d3
+	move.l	d3,c2p1x1_8_c5_030_2_scroffs
+	mulu.w	d0,d1
+	move.l	d1,c2p1x1_8_c5_030_2_pixels
+	movem.l	(sp)+,d2-d3
+	rts
+
+; a0	c2pscreen
+; a1	bitplanes
+
+	XDEF	_c2p1x1_8_c5_030_2
+	XDEF	c2p1x1_8_c5_030_2
+_c2p1x1_8_c5_030_2
+c2p1x1_8_c5_030_2
+	movem.l	d2-d7/a2-a6,-(sp)
+
+	move.l	#$00ff00ff,a6
+
+	add.w	#BPLSIZE,a1
+c2p1x1_8_c5_030_2_smc1 EQU *-2
+	add.l	c2p1x1_8_c5_030_2_scroffs,a1
+
+	lea	c2p1x1_8_c5_030_2_fastbuf,a3
+
+	move.l	c2p1x1_8_c5_030_2_pixels,a2
+	add.l	a0,a2
+	cmp.l	a0,a2
+	beq	.none
+
+	addq.l	#4,a2
+	move.l	a1,-(sp)
+
+	move.l	#$f0f0f0f0,d6
+
+	move.l	(a0)+,d2
+	move.l	d2,d7
+	lsl.l	#4,d7
+	move.l	(a0)+,d0
+	move.l	(a0)+,d3
+	move.l	(a0)+,d1
+	eor.l	d0,d7
+	and.l	d6,d7
+	eor.l	d7,d0
+	lsr.l	#4,d7
+	eor.l	d7,d2
+	move.l	d3,d7
+	lsl.l	#4,d7
+	eor.l	d1,d7
+	and.l	d6,d7
+	eor.l	d7,d1
+	move.l	d2,(a3)+
+	lsr.l	#4,d7
+	eor.l	d7,d3
+	move.l	d3,(a3)+
+
+	move.l	(a0)+,d4
+	move.l	d4,d7
+	lsl.l	#4,d7
+	move.l	(a0)+,d2
+	move.l	(a0)+,d5
+	move.l	(a0)+,d3
+	eor.l	d2,d7
+	and.l	d6,d7
+	eor.l	d7,d2
+	lsr.l	#4,d7
+	eor.l	d7,d4
+	move.l	d5,d7
+	lsl.l	#4,d7
+	eor.l	d3,d7
+	and.l	d6,d7
+	eor.l	d7,d3
+	move.l	d4,(a3)+
+	lsr.l	#4,d7
+	eor.l	d7,d5
+	move.l	d5,(a3)+
+
+	move.w	d2,d7			; Swap 16x2
+	move.w	d0,d2
+	swap	d2
+	move.w	d2,d0
+	move.w	d7,d2
+
+	move.w	d3,d7
+	move.w	d1,d3
+	swap	d3
+	move.w	d3,d1
+	move.w	d7,d3
+
+	bra.s	.start1
+.x1
+	move.l	(a0)+,d0
+	move.l	(a0)+,d3
+	move.l	(a0)+,d1
+	move.l	d7,BPLSIZE(a1)
+c2p1x1_8_c5_030_2_smc2 EQU *-2
+	move.l	d2,d7
+	lsl.l	#4,d7
+	eor.l	d0,d7
+	and.l	d6,d7
+	eor.l	d7,d0
+	lsr.l	#4,d7
+	eor.l	d7,d2
+	move.l	d3,d7
+	lsl.l	#4,d7
+	eor.l	d1,d7
+	and.l	d6,d7
+	eor.l	d7,d1
+	move.l	d2,(a3)+
+	lsr.l	#4,d7
+	eor.l	d7,d3
+	move.l	d3,(a3)+
+	move.l	d5,a5
+
+	move.l	(a0)+,d4
+	move.l	d4,d7
+	lsl.l	#4,d7
+	move.l	(a0)+,d2
+	move.l	(a0)+,d5
+	move.l	(a0)+,d3
+	move.l	a4,(a1)+
+	eor.l	d2,d7
+	and.l	d6,d7
+	eor.l	d7,d2
+	lsr.l	#4,d7
+	eor.l	d7,d4
+	move.l	d5,d7
+	lsl.l	#4,d7
+	eor.l	d3,d7
+	and.l	d6,d7
+	eor.l	d7,d3
+	lsr.l	#4,d7
+	eor.l	d7,d5
+
+	move.w	d2,d7			; Swap 16x2
+	move.w	d0,d2
+	swap	d2
+	move.w	d2,d0
+	move.l	d4,(a3)+
+	move.w	d7,d2
+
+	move.w	d3,d7
+	move.w	d1,d3
+	move.l	d5,(a3)+
+	swap	d3
+	move.w	d3,d1
+	move.w	d7,d3
+
+	move.l	a5,-BPLSIZE-4(a1)
+c2p1x1_8_c5_030_2_smc3 EQU *-2
+.start1
+	move.l	#$33333333,d5
+
+	move.l	d2,d7			; Swap 2x2
+	lsr.l	#2,d7
+	eor.l	d0,d7
+	and.l	d5,d7
+	eor.l	d7,d0
+	lsl.l	#2,d7
+	eor.l	d7,d2
+
+	move.l	d3,d7
+	lsr.l	#2,d7
+	eor.l	d1,d7
+	and.l	d5,d7
+	eor.l	d7,d1
+	lsl.l	#2,d7
+	eor.l	d7,d3
+
+	move.l	a6,d4
+	move.l	#$55555555,d5
+
+	move.l	d1,d7
+	lsr.l	#8,d7
+	eor.l	d0,d7
+	and.l	d4,d7
+	eor.l	d7,d0
+	lsl.l	#8,d7
+	eor.l	d7,d1
+
+	move.l	d1,d7
+	lsr.l	#1,d7
+	eor.l	d0,d7
+	and.l	d5,d7
+	eor.l	d7,d0
+	move.l	d0,BPLSIZE*2(a1)
+c2p1x1_8_c5_030_2_smc4 EQU *-2
+	add.l	d7,d7
+	eor.l	d1,d7
+
+	move.l	d3,d1
+	lsr.l	#8,d1
+	eor.l	d2,d1
+	and.l	d4,d1
+	eor.l	d1,d2
+	lsl.l	#8,d1
+	eor.l	d1,d3
+
+	move.l	d3,d1
+	lsr.l	#1,d1
+	eor.l	d2,d1
+	and.l	d1,d5
+	eor.l	d5,d2
+	move.l	d2,a4
+	move.l	(a0)+,d2
+	add.l	d5,d5
+	eor.l	d3,d5
+
+	cmpa.l	a0,a2
+	bne	.x1
+.x1end
+	move.l	d7,BPLSIZE(a1)
+c2p1x1_8_c5_030_2_smc5 EQU *-2
+	move.l	a4,(a1)+
+	move.l	d5,-BPLSIZE-4(a1)
+c2p1x1_8_c5_030_2_smc6 EQU *-2
+
+	move.l	(sp)+,a1
+	add.l	#BPLSIZE*4,a1
+c2p1x1_8_c5_030_2_smc7 EQU *-4
+
+	move.l	c2p1x1_8_c5_030_2_pixels,d0
+	lsr.l	#1,d0
+	lea	c2p1x1_8_c5_030_2_fastbuf,a0
+	lea	4(a0,d0.l),a2
+
+	move.l	(a0)+,d0
+	move.l	#$55555555,d4
+	move.l	#$33333333,d5
+	move.l	#$00ff00ff,d6
+	move.l	(a0)+,d1
+	move.l	(a0)+,d2
+	move.l	(a0)+,d3
+
+	move.w	d2,d7			; Swap 16x2
+	move.w	d0,d2
+	swap	d2
+	move.w	d2,d0
+	move.w	d7,d2
+
+	move.w	d3,d7
+	move.w	d1,d3
+	swap	d3
+	move.w	d3,d1
+	move.w	d7,d3
+
+	move.l	d2,d7			; Swap 2x2
+	lsr.l	#2,d7
+	eor.l	d0,d7
+	and.l	d5,d7
+	eor.l	d7,d0
+	lsl.l	#2,d7
+	eor.l	d7,d2
+
+	move.l	d3,d7
+	lsr.l	#2,d7
+	eor.l	d1,d7
+	and.l	d5,d7
+	eor.l	d7,d1
+	lsl.l	#2,d7
+	eor.l	d7,d3
+
+	move.l	d1,d7
+	lsr.l	#8,d7
+	bra.s	.start2
+.x2
+	move.l	(a0)+,d1
+	move.l	(a0)+,d2
+	move.l	(a0)+,d3
+	move.l	d7,BPLSIZE(a1)
+c2p1x1_8_c5_030_2_smc8 EQU *-2
+	move.w	d2,d7			; Swap 16x2
+	move.w	d0,d2
+	swap	d2
+	move.w	d2,d0
+	move.w	d7,d2
+
+	move.w	d3,d7
+	move.w	d1,d3
+	swap	d3
+	move.w	d3,d1
+	move.w	d7,d3
+
+	move.l	d2,d7			; Swap 2x2
+	lsr.l	#2,d7
+	eor.l	d0,d7
+	move.l	a4,(a1)+
+	and.l	d5,d7
+	eor.l	d7,d0
+	lsl.l	#2,d7
+	eor.l	d7,d2
+
+	move.l	d3,d7
+	lsr.l	#2,d7
+	eor.l	d1,d7
+	and.l	d5,d7
+	eor.l	d7,d1
+	lsl.l	#2,d7
+	eor.l	d7,d3
+
+	move.l	d1,d7
+	lsr.l	#8,d7
+	move.l	a5,-BPLSIZE-4(a1)
+c2p1x1_8_c5_030_2_smc9 EQU *-2
+.start2
+
+	eor.l	d0,d7
+	and.l	d6,d7
+	eor.l	d7,d0
+	lsl.l	#8,d7
+	eor.l	d7,d1
+
+	move.l	d1,d7
+	lsr.l	#1,d7
+	eor.l	d0,d7
+	and.l	d4,d7
+	eor.l	d7,d0
+	add.l	d7,d7
+	eor.l	d1,d7
+
+	move.l	d3,d1
+	move.l	d0,BPLSIZE*2(a1)
+c2p1x1_8_c5_030_2_smc10 EQU *-2
+	lsr.l	#8,d1
+	eor.l	d2,d1
+	and.l	d6,d1
+	eor.l	d1,d2
+	lsl.l	#8,d1
+	eor.l	d1,d3
+
+	move.l	d3,d1
+	lsr.l	#1,d1
+	eor.l	d2,d1
+	and.l	d4,d1
+	eor.l	d1,d2
+	add.l	d1,d1
+	eor.l	d1,d3
+
+	move.l	(a0)+,d0
+	move.l	d2,a4
+	move.l	d3,a5
+
+	cmpa.l	a0,a2
+	bne	.x2
+
+	move.l	d7,BPLSIZE(a1)
+c2p1x1_8_c5_030_2_smc11 EQU *-2
+	move.l	a4,(a1)+
+	move.l	a5,-BPLSIZE-4(a1)
+c2p1x1_8_c5_030_2_smc12 EQU *-2
+
+.none
+	movem.l	(sp)+,d2-d7/a2-a6
+	rts
+
+	section	bss,bss
+
+c2p1x1_8_c5_030_2_scroffs	ds.l	1
+c2p1x1_8_c5_030_2_pixels	ds.l	1
+
+c2p1x1_8_c5_030_2_fastbuf	ds.b	CHUNKYXMAX*CHUNKYYMAX/2

--- a/ab3d2_source/chunky.s
+++ b/ab3d2_source/chunky.s
@@ -1,5 +1,4 @@
-; TODO - Use CPU tuned Kalms C2P 1x1 and 2x1 for 030
-
+; TODO - Define C2P pointers for 2/3 size and use Kalms
 				; a0 src chunky ptr
 				; a1 dst chipmem ptr
 				; d0 number of pixels per line
@@ -49,6 +48,7 @@ Vid_ConvertC2P:
 				move.l	#(SCREEN_WIDTH/8)*256,d5
 
 				move.l	a2,-(sp)
+
 				move.l	Vid_ChunkyFS1x1InitPtr_l,a2
 				jsr		(a2)
 

--- a/ab3d2_source/chunky.s
+++ b/ab3d2_source/chunky.s
@@ -47,15 +47,20 @@ Vid_ConvertC2P:
 				sub.w	d3,d1					; top letterbox
 				sub.w	d3,d1					; bottom letterbox: d1: number of lines
 				move.l	#(SCREEN_WIDTH/8)*256,d5
-				jsr		c2p1x1_8_c5_040_init
+
+				move.l	a2,-(sp)
+				move.l	Vid_ChunkyFS1x1InitPtr_l,a2
+				jsr		(a2)
 
 				; scroffsy only accounts for the Y offset in the destination buffer
 				move.l	Vid_FastBufferPtr_l,a0
 				mulu.w	#SCREEN_WIDTH,d3
 				lea		(a0,d3.w),a0
 				move.l	Vid_DrawScreenPtr_l,a1
-				jsr		c2p1x1_8_c5_040
+				move.l	Vid_ChunkyFS1x1ConvPtr_l,a2
+				jsr		(a2)
 
+				move.l	(sp)+,a2
 .nothingLeft:
 				rts
 

--- a/ab3d2_source/chunky.s
+++ b/ab3d2_source/chunky.s
@@ -1,3 +1,5 @@
+; TODO - Use CPU tuned Kalms C2P 1x1 and 2x1 for 030
+
 				; a0 src chunky ptr
 				; a1 dst chipmem ptr
 				; d0 number of pixels per line

--- a/ab3d2_source/data/game_data.s
+++ b/ab3d2_source/data/game_data.s
@@ -7,10 +7,22 @@
 _game_PropertiesFile::
 game_PropertiesFile_vb:			dc.b	"ab3:Includes/game.props",0
 
+			IFD BUILD_WITH_C
+
 _game_PreferencesFile::
 game_PreferencesFile_vb:		dc.b	"ab3:game.prefs",0
 
 _game_ProgressFile::
 game_ProgressFile_vb:			dc.b	"ab3:game.stats",0
+
+			ELSE
+
+_game_PreferencesFile::
+game_PreferencesFile_vb:		dc.b	"ab3:gamea.prefs",0
+
+_game_ProgressFile::
+game_ProgressFile_vb:			dc.b	"ab3:gamea.stats",0
+
+			ENDC
 
 Game_SavedGamesName_vb:			dc.b	"ab3:boot.dat",0

--- a/ab3d2_source/defs.i
+++ b/ab3d2_source/defs.i
@@ -460,15 +460,15 @@ MAX_ACHIEVEMENTS EQU 128
 		UWORD GStatT_AlienKills_vw
 		PADDING (NUM_ALIEN_DEFS*2)-2			; 40 - UWORD[NUM_ALIEN_DEFS]
 
-        ; Total health collected
-        ULONG GStatT_TotalHealthCollected_w     ; 4
+		; Total health collected
+		ULONG GStatT_TotalHealthCollected_w     ; 4
 
-        ; Total fuel collected
-        ULONG GStatT_TotalFuelCollected_w       ; 4
+		; Total fuel collected
+		ULONG GStatT_TotalFuelCollected_w       ; 4
 
-        ; Total ammo collected, per ammo class
-        ULONG GStatT_TotalAmmoFound_vw
-        PADDING (NUM_BULLET_DEFS*4)-4           ; 80 UWORD[NUM_BULLET_DEFS]
+		; Total ammo collected, per ammo class
+		ULONG GStatT_TotalAmmoFound_vw
+		PADDING (NUM_BULLET_DEFS*4)-4           ; 80 UWORD[NUM_BULLET_DEFS]
 
 		UBYTE GStatT_Achieved_vb
 		PADDING (MAX_ACHIEVEMENTS/8)-1

--- a/ab3d2_source/hires.s
+++ b/ab3d2_source/hires.s
@@ -5898,10 +5898,7 @@ tstwat:
 				bne		draw_WaterSurface
 ; tst.b draw_UseGouraudFlats_b					; FIXME: this effectively disables bumpmapped floors...
 												; opportunity to reenable and see what happens
-				;bra		gouraudfloor
 
-				tst.b	Sys_CPU_68060_b
-				bne		draw_GoraudFloor060
 				bra		draw_GoraudFloor
 
 ordinary:
@@ -5972,11 +5969,11 @@ gotoacross:
 leftbright:		dc.l  0
 brightspd:		dc.l  0
 
+				IFD OPT060
 				include "modules/draw/draw_floor_060.s"
-
-				align 4
-
+				ELSE
 				include "modules/draw/draw_floor.s"
+				ENDC
 
 				align 4
 

--- a/ab3d2_source/hires.s
+++ b/ab3d2_source/hires.s
@@ -8861,6 +8861,12 @@ welldone:
 				include	"serial_nightmare.s"
 
 				cnop	0,4
+
+				IFND OPT060
+				IFND OPT040
+				include "c2p1x1_8_c5_030_2.s"
+				ENDC
+				ENDC
 				include	"c2p1x1_8_c5_040.s"
 				include	"c2p_rect.s"
 				include	"c2p2x1_8_c5_gen.s"

--- a/ab3d2_source/hireswall.s
+++ b/ab3d2_source/hireswall.s
@@ -1313,140 +1313,14 @@ nocliptop:
 .nsbd:
 				bra		gotoend
 
-;wlcnt:			dc.w	0 ; unused
 
-				ifd OPT060
-
-drawwallS060_loop	macro
-val set \2
-.loop\<val>:
-				; grab packed texel
-				ifeq    \1-0
-				moveq   #%00011111,d1
-				and.b   1(a5,d4.w*2),d1
-				endc
-				ifeq    \1-1
-				move.w  (a5,d4.w*2),d1
-				lsr.w   #5,d1
-				and.w   #%00011111,d1
-				endc
-				ifeq    \1-2
-				moveq   #%01111100,d1
-				and.b   (a5,d4.w*2),d1
-				lsr.b   #2,d1
-				endc
-
-				; v step (fractional first, then integer part)
-				add.l   d3,d4
-				addx.w  d2,d4
-				and.w   d7,d4
-
-				; store through palette lookup (note: alternates between a2 and a4)
-				ifeq \2
-				move.b  (a2,d1.w*2),(a3)
-				else
-				move.b  (a4,d1.w*2),(a3)
-				endc
-
-				; dest += width
-				adda.w  d0,a3
-val set val^1
-				dbf     d6,.loop\<val>
-				rts
-				endm
-
-drawwallS060	macro
-				and.w   d7,d4   ; make sure offset is masked
-				drawwallS060_loop \1,0
-				drawwallS060_loop \1,1
-				endm
-
-drawwallPACK0:	drawwallS060 0
-drawwallPACK1:	drawwallS060 1
-drawwallPACK2:	drawwallS060 2
-
-				else ; OPT060
+				IFD OPT060
+				include "modules/draw/draw_wall_060.s"
+				ELSE
+				include "modules/draw/draw_wall.s"
+				ENDC
 
 				align 4
-drawwalldimPACK0:
-				and.w	d7,d4
-				move.b	1(a5,d4.w*2),d1			; fetch texel
-				and.b	#31,d1					; pull out right part
-				add.l	d3,d4					; add fractional part?
-				move.b	(a4,d1.w*2),(a3)
-				adda.w	d0,a3					; next line in screen
-				addx.w	d2,d4					; texture Y + dy
-				dbra	d6,drawwallPACK0
-				rts
-
-				;CNOP	0,128
-				align 4
-drawwallPACK0:
-				and.w	d7,d4
-				move.b	1(a5,d4.w*2),d1
-				and.b	#31,d1
-				add.l	d3,d4
-				move.b	(a2,d1.w*2),(a3)
-				adda.w	d0,a3
-				addx.w	d2,d4
-				dbra	d6,drawwalldimPACK0
-
-nostrip:
-				rts
-
-				align 4
-drawwalldimPACK1:
-				and.w	d7,d4
-				move.w	(a5,d4.w*2),d1
-				lsr.w	#5,d1
-				and.w	#31,d1
-				add.l	d3,d4
-				move.b	(a4,d1.w*2),(a3)
-				adda.w	d0,a3
-				addx.w	d2,d4
-				dbra	d6,drawwallPACK1
-				rts
-
-				align 4
-drawwallPACK1:
-				and.w	d7,d4
-				move.w	(a5,d4.w*2),d1
-				lsr.w	#5,d1
-				and.w	#31,d1
-				add.l	d3,d4
-				move.b	(a2,d1.w*2),(a3)
-				adda.w	d0,a3
-				addx.w	d2,d4
-				dbra	d6,drawwalldimPACK1
-
-				rts
-
-				align 4
-drawwalldimPACK2:
-				and.w	d7,d4
-				move.b	(a5,d4.w*2),d1
-				lsr.b	#2,d1
-				add.l	d3,d4
-				move.b	(a4,d1.w*2),(a3)
-				adda.w	d0,a3
-				addx.w	d2,d4
-				dbra	d6,drawwallPACK2
-				rts
-
-				align 4
-drawwallPACK2:
-				and.w	d7,d4
-				move.b	(a5,d4.w*2),d1
-				lsr.b	#2,d1
-				add.l	d3,d4
-				move.b	(a2,d1.w*2),(a3)
-				adda.w	d0,a3
-				addx.w	d2,d4
-				dbra	d6,drawwalldimPACK2
-				rts
-
-				endc ; OPT060
-
 usesimple:
 				mulu	d3,d4
 				add.l	d0,d4

--- a/ab3d2_source/kmake.sh
+++ b/ab3d2_source/kmake.sh
@@ -1,19 +1,13 @@
 # This script is for building the binaries in the karlos-tkg mod. Probably needs removing from this repo.
 
 rm ../../../miscdrive/karlos-tkg/Game/bin/*
-make clean
-make hires hiresC
+make clean && make rel040
 
-# Make sure they are stripped
-m68k-amigaos-strip hires
-m68k-amigaos-strip hiresC
+cp tkg_040 ../../../miscdrive/karlos-tkg/Game/bin/tkg_asm
+cp tkgc_040 ../../../miscdrive/karlos-tkg/Game/bin/tkg_c
 
-cp hires ../../../miscdrive/karlos-tkg/Game/bin/tkg_asm
-cp hiresC ../../../miscdrive/karlos-tkg/Game/bin/tkg_c
+make clean && make dev040
 
-make clean
-
-make dev 
-cp hires ../../../miscdrive/karlos-tkg/Game/bin/tkg_asm_dev
-cp hiresC ../../../miscdrive/karlos-tkg/Game/bin/tkg_c_dev
+cp tkg_dev_040 ../../../miscdrive/karlos-tkg/Game/bin/tkg_asm_dev
+cp tkgc_dev_040 ../../../miscdrive/karlos-tkg/Game/bin/tkg_c_dev
 

--- a/ab3d2_source/kmake2.sh
+++ b/ab3d2_source/kmake2.sh
@@ -1,0 +1,13 @@
+# This script is for building the binaries in the karlos-tkg mod. Probably needs removing from this repo.
+
+make clean && make rel
+make clean && make test
+make clean && make dev
+
+make clean && make rel040
+make clean && make test040
+make clean && make dev040
+
+make clean && make rel060
+make clean && make test060
+make clean && make dev060

--- a/ab3d2_source/modules/draw/draw_floor_060.s
+++ b/ab3d2_source/modules/draw/draw_floor_060.s
@@ -1,6 +1,6 @@
 ; 68060 optimised Gouraud Floor routine by @paraj / @saimo
 
-draw_GoraudFloor060:
+draw_GoraudFloor:
 				moveq   #0,d0
 				move.w	leftbright,d0
 				move.w  brightspd,d4

--- a/ab3d2_source/modules/draw/draw_wall.s
+++ b/ab3d2_source/modules/draw/draw_wall.s
@@ -1,0 +1,80 @@
+
+; 68020+ generc inner wall rendering loop
+
+drawwalldimPACK0:
+				and.w	d7,d4
+				move.b	1(a5,d4.w*2),d1			; fetch texel
+				and.b	#31,d1					; pull out right part
+				add.l	d3,d4					; add fractional part?
+				move.b	(a4,d1.w*2),(a3)
+				adda.w	d0,a3					; next line in screen
+				addx.w	d2,d4					; texture Y + dy
+				dbra	d6,drawwallPACK0
+				rts
+
+				;CNOP	0,128
+				align 4
+drawwallPACK0:
+				and.w	d7,d4
+				move.b	1(a5,d4.w*2),d1
+				and.b	#31,d1
+				add.l	d3,d4
+				move.b	(a2,d1.w*2),(a3)
+				adda.w	d0,a3
+				addx.w	d2,d4
+				dbra	d6,drawwalldimPACK0
+
+nostrip:
+				rts
+
+				align 4
+drawwalldimPACK1:
+				and.w	d7,d4
+				move.w	(a5,d4.w*2),d1
+				lsr.w	#5,d1
+				and.w	#31,d1
+				add.l	d3,d4
+				move.b	(a4,d1.w*2),(a3)
+				adda.w	d0,a3
+				addx.w	d2,d4
+				dbra	d6,drawwallPACK1
+				rts
+
+				align 4
+drawwallPACK1:
+				and.w	d7,d4
+				move.w	(a5,d4.w*2),d1
+				lsr.w	#5,d1
+				and.w	#31,d1
+				add.l	d3,d4
+				move.b	(a2,d1.w*2),(a3)
+				adda.w	d0,a3
+				addx.w	d2,d4
+				dbra	d6,drawwalldimPACK1
+
+				rts
+
+				align 4
+drawwalldimPACK2:
+				and.w	d7,d4
+				move.b	(a5,d4.w*2),d1
+				lsr.b	#2,d1
+				add.l	d3,d4
+				move.b	(a4,d1.w*2),(a3)
+				adda.w	d0,a3
+				addx.w	d2,d4
+				dbra	d6,drawwallPACK2
+				rts
+
+				align 4
+drawwallPACK2:
+				and.w	d7,d4
+				move.b	(a5,d4.w*2),d1
+				lsr.b	#2,d1
+				add.l	d3,d4
+				move.b	(a2,d1.w*2),(a3)
+				adda.w	d0,a3
+				addx.w	d2,d4
+				dbra	d6,drawwalldimPACK2
+				rts
+

--- a/ab3d2_source/modules/draw/draw_wall_060.s
+++ b/ab3d2_source/modules/draw/draw_wall_060.s
@@ -1,0 +1,49 @@
+
+; 68060 tuned inner wall rendering loop by @paraj
+drawwallS060_loop	MACRO
+val SET \2
+.loop\<val>:
+				; grab packed texel
+				IFEQ    \1-0
+				moveq   #%00011111,d1
+				and.b   1(a5,d4.w*2),d1
+				ENDC
+				IFEQ    \1-1
+				move.w  (a5,d4.w*2),d1
+				lsr.w   #5,d1
+				and.w   #%00011111,d1
+				ENDC
+				IFEQ    \1-2
+				moveq   #%01111100,d1
+				and.b   (a5,d4.w*2),d1
+				lsr.b   #2,d1
+				ENDC
+
+				; v step (fractional first, then integer part)
+				add.l   d3,d4
+				addx.w  d2,d4
+				and.w   d7,d4
+
+				; store through palette lookup (note: alternates between a2 and a4)
+				IFEQ \2
+				move.b  (a2,d1.w*2),(a3)
+				ELSE
+				move.b  (a4,d1.w*2),(a3)
+				ENDC
+
+				; dest += width
+				adda.w  d0,a3
+val SET val^1
+				dbf     d6,.loop\<val>
+				rts
+				ENDM
+
+drawwallS060	MACRO
+				and.w   d7,d4   ; make sure offset is masked
+				drawwallS060_loop \1,0
+				drawwallS060_loop \1,1
+				ENDM
+
+drawwallPACK0:	drawwallS060 0
+drawwallPACK1:	drawwallS060 1
+drawwallPACK2:	drawwallS060 2

--- a/ab3d2_source/modules/vid.s
+++ b/ab3d2_source/modules/vid.s
@@ -12,7 +12,38 @@ VID_BRIGHT_ADJ_MAX	EQU	5120
 
 				align 4
 
-;
+_Vid_InitC2P::
+Vid_InitC2P:
+				IFND OPT060
+				IFND OPT040
+
+				; Generic build
+				; Runtime detection which C2P routines to use
+				tst.b	Sys_Move16_b ; if set, we have an 040 or 060
+				beq.s	.use_030
+
+				; Opt for Kalm's 040/060 C2P routines
+				move.l	#c2p1x1_8_c5_040_init,Vid_ChunkyFS1x1InitPtr_l
+				move.l	#c2p1x1_8_c5_040,Vid_ChunkyFS1x1ConvPtr_l
+				rts
+
+.use_030:
+				; Otherwise use the v2 030 C2P routine
+				move.l	#c2p1x1_8_c5_030_2_init,Vid_ChunkyFS1x1InitPtr_l
+				move.l	#c2p1x1_8_c5_030_2,Vid_ChunkyFS1x1ConvPtr_l
+
+				ELSE ; OPT040
+				move.l	#c2p1x1_8_c5_040_init,Vid_ChunkyFS1x1InitPtr_l
+				move.l	#c2p1x1_8_c5_040,Vid_ChunkyFS1x1ConvPtr_l
+				ENDC
+				ELSE ; OPT060
+				move.l	#c2p1x1_8_c5_040_init,Vid_ChunkyFS1x1InitPtr_l
+				move.l	#c2p1x1_8_c5_040,Vid_ChunkyFS1x1ConvPtr_l
+				ENDC
+
+				rts
+
+				;
 ; a5 contains keyboard state. No regs clobbered.
 ;
 Vid_CheckSettingsAdjust:

--- a/ab3d2_source/modules/vid.s
+++ b/ab3d2_source/modules/vid.s
@@ -14,6 +14,10 @@ VID_BRIGHT_ADJ_MAX	EQU	5120
 
 _Vid_InitC2P::
 Vid_InitC2P:
+;				move.l	#c2p1x1_8_c5_030_2_init,Vid_ChunkyFS1x1InitPtr_l
+;				move.l	#c2p1x1_8_c5_030_2,Vid_ChunkyFS1x1ConvPtr_l
+;				rts
+
 				IFND OPT060
 				IFND OPT040
 

--- a/ab3d2_source/screensetup.s
+++ b/ab3d2_source/screensetup.s
@@ -8,6 +8,7 @@ vid_MyAllocRaster:
 				rts
 
 Vid_OpenMainScreen:
+				jsr		Vid_InitC2P
 				; Allocate Buffer 0
 				lea		vid_MainBitmap0,a0
 				moveq.l	#8,d0


### PR DESCRIPTION
Introduces a build model that allows for dev, test and release builds of the engine, with additional 040 and 060 specific targets.
- Reduces runtime-specific indirection 
- Allows for deeper optimisation by factoring out assembler code into sources for specific CPUs and macros to be declared in CPU specific ways
- Allows for C code to be specifically tuned for the target.

- 060 optimised routines used in 060 build
- Adds 030 tuned c2p routines for the generic build.