### PR TITLE
Mheyer/misc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 ab3d2_source/hires
 ab3d2_source/hiresC
 ab3d2_source/listing.txt
+/.qtc_clangd/*

--- a/ab3d2_source/bss/system_bss.s
+++ b/ab3d2_source/bss/system_bss.s
@@ -21,8 +21,8 @@ _DOSBase:					ds.l	1
 						ENDIF
 _GfxBase::					ds.l	1
 _IntuitionBase::			ds.l	1
-_MiscResourceBase::			ds.l	1
-_PotgoResourceBase::		ds.l	1
+_MiscBase::                 ds.l	1
+_PotgoBase::                ds.l	1
 _TimerBase::				ds.l	1
 
 ; Chunk of statically allocated data for various calculations

--- a/ab3d2_source/hires.s
+++ b/ab3d2_source/hires.s
@@ -8775,7 +8775,7 @@ closeeverything:
 				jsr		Res_FreeLevelData
 				jsr		Res_ReleaseScreenMemory
 ;
-;				move.l	_MiscResourceBase,d0
+;				move.l	_MiscBase,d0
 ;				beq.s	.noMiscResourceBase
 ;				move.l	d0,a6
 ;				; FIXME: would need to check if we actually allocated them successfully
@@ -8784,7 +8784,7 @@ closeeverything:
 ;				move.l	#MR_SERIALBITS,d0
 ;				jsr		_LVOFreeMiscResource(a6)
 ;
-;				clr.l	_MiscResourceBase		; Resource library doesn't have a 'close'?
+;				clr.l	_MiscBase		; Resource library doesn't have a 'close'?
 ;
 ;.noMiscResourceBase
 ;

--- a/ab3d2_source/modules/system.s
+++ b/ab3d2_source/modules/system.s
@@ -548,7 +548,7 @@ sys_OpenLibs:
 				lea.l		MiscResourceName,a1
 				CALLEXEC 	OpenResource
 
-				move.l		d0,_MiscResourceBase
+				move.l		d0,_MiscBase
                 beq.s	   	.fail
 
 				; Potgo Resource
@@ -556,7 +556,7 @@ sys_OpenLibs:
 				lea.l		PotgoResourceName,a1
 				CALLEXEC 	OpenResource
 
-				move.l		d0,_PotgoResourceBase
+				move.l		d0,_PotgoBase
 				beq.s   	.fail
 
 				; Timer Device

--- a/ab3d2_source/system.i
+++ b/ab3d2_source/system.i
@@ -83,11 +83,11 @@ CALLDOS			MACRO
 				ENDM
 
 CALLMISC		MACRO
-				move.l	_MiscResourceBase,a6
+				move.l	_MiscBase,a6
 				jsr		_LVO\1(a6)
 				ENDM
 
 CALLPOTGO		MACRO
-				move.l	_PotgoResourceBase,a6
+				move.l	_PotgoBase,a6
 				jsr		_LVO\1(a6)
 				ENDM


### PR DESCRIPTION
I had trouble starting the latest executable. It was giving me "failed to load misc.resource" and "failed to load potgo.resource" messages and just quit. The cause seems to be a change in a recent version of Libnix which tries to auto-open these resources as libraries.