### PR TITLE
Revamp makefile to build executables for each CPU, flavor and (C-)build

### DIFF
--- a/ab3d2_source/Makefile
+++ b/ab3d2_source/Makefile
@@ -1,184 +1,123 @@
+#disable built-in rules
+.SUFFIXES:
+# don't delete intermeditae .o and build directories
+.PRECIOUS: %.o %/.
+#enable second expansion, so we can use $(@D) as dependency
+.SECONDEXPANSION:
+
 CC=m68k-amigaos-gcc
 LINK=m68k-amigaos-gcc
 ASS=vasmm68k_mot
 VLINK=vlink
-
 STRIP=m68k-amigaos-strip
 
 #find the toolchain's directory
 PREFIX = $(shell ./getprefix.sh "$(CC)")
 
-#-DCD32VER
+FLAVORS =dev test release
+CPUS =060 040 030
+BUILDS =c asm
 
-CFLAGS = -noixemul -O3
-LFLAGS = -noixemul
+FLAVOR ?=dev
+CPU ?=060
+BUILD ?=c
 
-# Allow 040+ instructions to be emitted in runtime detection cases
+TARGETNAME = tkg$(BUILD)_$(FLAVOR)_$(CPU)
+
+SRC_DIR = c
+BUILD_DIR ?= _build
+INTERMEDIATE_DIR = $(BUILD_DIR)/$(CPU)/$(FLAVOR)/$(BUILD)
+
+SRCS = $(wildcard $(SRC_DIR)/*.c)
+OBJS = $(INTERMEDIATE_DIR)/hires.o
+
+ifeq ($(BUILD),c)
+	OBJS +=$(SRCS:$(SRC_DIR)/%.c=$(INTERMEDIATE_DIR)/%.o) 
+endif
+
+#- DCD32VER
+CFLAGS += -noixemul
+LFLAGS += -noixemul 
+
+#Allow 040 + instructions to be emitted in runtime detection cases
 AFLAGS = -Fhunk -m68060 -linedebug -chklabels -align -L listing.txt -Dmnu_nocode=1 -DUSE_16X16_TEXEL_MULS
-
 AFLAGS += -I../ \
 		  -I$(PREFIX)/m68k-amigaos/ndk-include \
 		  -I../media \
 		  -I../media/includes
 
-#AFLAGS += -DMEMTRACK=1
+#AFLAGS += -DMEMTRACK = 1
 
 VFLAGS = -b amigahunk -sc -l amiga -L $(PREFIX)m68k-amigaos/ndk/lib/libs
 
-# Generic dev builds - dev features, debugging on, unstripped
-dev:	tkg_dev tkgc_dev
-dev:	AFLAGS += -DDEV=1 -DZONE_DEBUG=1
-dev:	CFLAGS += -m68020-60 -mtune=68030 -DDEV -DZONE_DEBUG -g -ggdb
-dev:	LFLAGS += -g -ggdb
+ifeq ($(FLAVOR),dev)
+	AFLAGS += -DDEV=1 -DZONE_DEBUG=1
+	CFLAGS += -O3 -DDEV -DZONE_DEBUG
+	LFLAGS += -g -ggdb
+else ifeq ($(FLAVOR),test)
+	LFLAGS += -g -ggdb
+	CFLAGS += -O3
+else
+	CFLAGS += -O3
+endif
 
-# Generic test builds, release features, debugging on, unstripped
-test:	tkg_test tkgc_test
-test:	CFLAGS += -m68020-60 -mtune=68030 -g -ggdb
-test:	LFLAGS += -g -ggdb
+ifeq ($(CPU),040)
+	AFLAGS += -DOPT040
+	CFLAGS += -m68040 -mtune=68040
+else ifeq ($(CPU),060)
+	AFLAGS += -DOPT060
+	CFLAGS += -m68060 -mtune=68060
+else
+	CFLAGS += -m68020-60 -mtune=68030
+endif
 
-# Generic release builds, release features, debugging off, stripped
-rel:	tkg tkgc
-rel:	CFLAGS+=-m68020-60 -mtune=68030
-rel:
-	$(STRIP) --strip-debug --strip-unneeded tkg
-	$(STRIP) --strip-debug --strip-unneeded tkgc
+ifeq ($(BUILD),c)
+	AFLAGS += -DBUILD_WITH_C
+#Use gcc for linking the C build
+$(TARGETNAME): $(OBJS)
+	$(info Linking $@)
+	$(LINK) $(LFLAGS) $(OBJS) -o $@ 
+	$(info ========================================================)
+else
+	LFLAGS += -nostartfiles -nodefaultlibs
+#Use vlink for linking the ASM build. For some reason, attempting to link with gcc's linker will result in unresolved symbols
+$(TARGETNAME): $(OBJS)
+	$(info Linking $@)
+	$(VLINK) $(VFLAGS) $(OBJS) -o $@ 
+	$(info ========================================================)
+endif
 
-# 68040 tuned dev builds
-dev040:	tkg_dev_040 tkgc_dev_040
-dev040:	AFLAGS += -DDEV=1 -DZONE_DEBUG=1 -DOPT040
-dev040:	CFLAGS += -m68040 -mtune=68040 -DDEV -DZONE_DEBUG -g -ggdb
-dev040:	LFLAGS += -g -ggdb
 
-# 68040 tuned test builds
-test040:	tkg_test_040 tkgc_test_040
-test040:	CFLAGS += -m68040 -mtune=68040 -g -ggdb
-test040:	LFLAGS += -g -ggdb
+all: $(foreach F,$(FLAVORS),$(foreach C,$(CPUS),$(foreach T,$(BUILDS),build-$(F)-$(C)-$(T))))
 
-# 68040 tuned release builds
-rel040:	tkg_040 tkgc_040
-rel040:	AFLAGS += -DOPT040
-rel040:	CFLAGS += -m68040 -mtune=68040
-rel040:
-	$(STRIP) --strip-debug --strip-unneeded tkg_040
-	$(STRIP) --strip-debug --strip-unneeded tkgc_040
-
-# 68060 tuned dev builds
-dev060:	tkg_dev_060 tkgc_dev_060
-dev060:	AFLAGS += -DDEV=1 -DZONE_DEBUG=1  -DOPT060
-dev060:	CFLAGS += -m68060 -mtune=68060 -DDEV -DZONE_DEBUG -g -ggdb
-dev060:	LFLAGS += -g -ggdb
-
-# 68060 tuned test builds
-test060:	tkg_test_060 tkgc_test_060
-test060:	CFLAGS += -m68060 -mtune=68060 -g -ggdb
-test060:	LFLAGS += -g -ggdb
-
-# 68060 tuned release builds
-rel060:	tkg_060 tkgc_060
-rel060:	AFLAGS += -DOPT060
-rel060:	CFLAGS += -m68060 -mtune=68060
-rel060:
-	$(STRIP) --strip-debug --strip-unneeded tkg_060
-	$(STRIP) --strip-debug --strip-unneeded tkgc_060
-
-OBJS = c/main.o \
-	   c/screen.o \
-	   c/system.o \
-	   c/menu.o \
-	   c/draw.o \
-	   c/message.o \
-	   c/game_properties.o \
-	   c/game_preferences.o \
-	   c/game_progress.o \
-	   c/game.o \
-	   c/zone_debug.o \
-	   c/zone_errata.o \
-	   c/zone_edge_pvs.o \
-	   c/hires.o
-
-# GENERIC ##################################
-
-tkg_dev: hires.o
-	$(VLINK) $(VFLAGS) $< -o $@
-
-tkgc_dev:	AFLAGS+=-DBUILD_WITH_C
-tkgc_dev:	${OBJS}
-	$(LINK) $(LFLAGS) $^ -o $@
-
-tkg_test: hires.o
-	$(VLINK) $(VFLAGS) $< -o $@
-
-tkgc_test:	AFLAGS+=-DBUILD_WITH_C
-tkgc_test:	${OBJS}
-	$(LINK) $(LFLAGS) $^ -o $@
-
-tkg: hires.o
-	$(VLINK) $(VFLAGS) $< -o $@
-
-tkgc:	AFLAGS+=-DBUILD_WITH_C
-tkgc:	${OBJS}
-	$(LINK) $(LFLAGS) $^ -o $@
-
-# 68040 ##################################
-
-tkg_dev_040: hires.o
-	$(VLINK) $(VFLAGS) $< -o $@
-
-tkgc_dev_040:	AFLAGS+=-DBUILD_WITH_C
-tkgc_dev_040:	${OBJS}
-	$(LINK) $(LFLAGS) $^ -o $@
-
-tkg_test_040: hires.o
-	$(VLINK) $(VFLAGS) $< -o $@
-
-tkgc_test_040:	AFLAGS+=-DBUILD_WITH_C
-tkgc_test_040:	${OBJS}
-	$(LINK) $(LFLAGS) $^ -o $@
-
-tkg_040: hires.o
-	$(VLINK) $(VFLAGS) $< -o $@
-
-tkgc_040:	AFLAGS+=-DBUILD_WITH_C
-tkgc_040:	${OBJS}
-	$(LINK) $(LFLAGS) $^ -o $@
-
-# 68060 ##################################
-
-tkg_dev_060: hires.o
-	$(VLINK) $(VFLAGS) $< -o $@
-
-tkgc_dev_060:	AFLAGS+=-DBUILD_WITH_C
-tkgc_dev_060:	${OBJS}
-	$(LINK) $(LFLAGS) $^ -o $@
-
-tkg_test_060: hires.o
-	$(VLINK) $(VFLAGS) $< -o $@
-
-tkgc_test_060:	AFLAGS+=-DBUILD_WITH_C
-tkgc_test_060:	${OBJS}
-	$(LINK) $(LFLAGS) $^ -o $@
-
-tkg_060: hires.o
-	$(VLINK) $(VFLAGS) $< -o $@
-
-tkgc_060:	AFLAGS+=-DBUILD_WITH_C
-tkgc_060:	${OBJS}
-	$(LINK) $(LFLAGS) $^ -o $@
-
+build-%:
+	$(eval FLAVOR := $(strip $(word 1,$(subst -, ,$*))))
+	$(eval CPU := $(strip $(word 2,$(subst -, ,$*))))
+	$(eval BUILD := $(strip $(word 3,$(subst -, ,$*))))
+	$(if $(FLAVOR),,$(error Missing FLAVOR in $*))
+	$(if $(CPU),,$(error Missing CPU in $*))
+	$(if $(BUILD),,$(error Missing BUILD in $*))
+	$(MAKE) FLAVOR=$(FLAVOR) CPU=$(CPU) BUILD=$(BUILD) $(TARGETNAME)
 #############################################################
 
 clean:
 	rm -f *.o
-	rm -f ${OBJS}
+	rm -rf $(BUILD_DIR)
 
-c/%.o: %.s Makefile
-	$(ASS) $(AFLAGS) $< -o $@
+$(INTERMEDIATE_DIR)/%.o: $(SRC_DIR)/%.c Makefile
+	$(info >>> build $@ from $<)
+	@mkdir -p $(@D)
+	@$(CC) $(CFLAGS) -c $< -o $@
+	
+$(INTERMEDIATE_DIR)/%.o: $(SRC_DIR)/%.s Makefile
+	$(info >>> build $@ from $<)
+	@mkdir -p $(@D)
+	@$(ASS) $(AFLAGS) $< -o $@
 
-%.o: %.s Makefile
-	$(ASS) $(AFLAGS) $< -o $@
-
-%.o: %.c Makefile
-	$(CC) $(CFLAGS) -c $< -o $@
+$(INTERMEDIATE_DIR)/%.o: %.s Makefile
+	$(info >>> build $@ from $<)
+	@mkdir -p $(@D)
+	@$(ASS) $(AFLAGS) $< -o $@
 
 %_stripped:	%
 	$(STRIP) --strip-debug --strip-unneeded -o $@ $<


### PR DESCRIPTION
In particular make it so that the object files end up in dedicated directories, so one can keep each build combo at the same time without fear of "contaminating" each other. This will also support creating CI  builds on GitHub in future.

To do this, allow the makefile to be provided with 3 'flavors' via environment variable FLAVOR:
	* dev (default)
	* test
	* release 3  CPU types via 'CPU'
	* 060 (default)
	* 040
	* 030 and two build types 'BUILD'
	* c (default)
	* asm

Invoke the make file like so:
make FLAVOR=release CPU=040 BUILD=c

will build the target 'tkgc_dev_060'

The 'all' make target loops over all combinations of flavor, cpu and build type and invokes 'Makefile' with the corresponding environment variables.