### PR TITLE
Crossing checks for Edge PVS

### DIFF
--- a/ab3d2_source/bss/zone_bss.s
+++ b/ab3d2_source/bss/zone_bss.s
@@ -13,8 +13,9 @@ Zone_OrderTable_Barrier_w:		ds.w	1 		; needs initialisation to -1
 Zone_FinalOrderTable_vw:		ds.w	400*2
 zone_FinalOrderTableBarrier_w:	ds.w	1 		; deliniates end of table
 
-		DCLC Zone_VisJoins_w,	ds.w,	1
-		DCLC Zone_TotJoins_w,	ds.w,	1
+		DCLC Zone_VisJoins_w,	ds.w,	1 		; The nuber of visible joins in the current zone
+		DCLC Zone_TotJoins_w,	ds.w,	1 		; The total number joins in the current zone
+		DCLC Zone_VisJoinMask_w,	ds.w,	1 		; Bitmap of the visible joining edges
 		;DCLC Zone_EdgeClipIndexes_vw, ds.w, 2
 
 		DCLC Zone_EdgePointIndexes_vw, ds.w, 32

--- a/ab3d2_source/c/zone.h
+++ b/ab3d2_source/c/zone.h
@@ -191,14 +191,34 @@ extern ZEdgePVSHeader** Lvl_ZEdgePVSHeaderPtrsPtr_l;
 /** Number of visible joining endges currently in view */
 extern WORD Zone_VisJoins_w;
 
-/** Array indexes of the end coordinates of the visible joining edge when Zone_VisJoins_w == 1 */
-//extern WORD Zone_EdgeClipIndexes_vw[2];
-
 /** Onscreen maximum clip extents - either the full screen, or the portion visible through the edge */
 extern WORD Draw_ZoneClipL_w;
 extern WORD Draw_ZoneClipR_w;
 
-void Zone_UpdateVectors(void);
 void Zone_CheckVisibleEdges(void);
+
+/**
+ * Enumeration of the possible crossings from one Zone to another via their shared edge.
+ */
+typedef enum {
+    NO_PATH        = 0, // No height overlaps
+    LOWER_TO_LOWER = 1, // Lower halves of zones overlap
+    LOWER_TO_UPPER = 2, // Lower half of source zone overlaps with upper half of destination zone
+    LOWER_TO_BOTH  = 3, // Lower zone of source overlaps with both zones
+
+    UPPER_TO_LOWER = LOWER_TO_LOWER << 2,
+    UPPER_TO_UPPER = LOWER_TO_UPPER << 2,
+    UPPER_TO_BOTH  = LOWER_TO_BOTH  << 2,
+
+    BOTH_TO_LOWER  = LOWER_TO_LOWER|UPPER_TO_LOWER,
+    BOTH_TO_UPPER  = LOWER_TO_UPPER|UPPER_TO_UPPER,
+    BOTH           = LOWER_TO_LOWER|UPPER_TO_UPPER
+} ZoneCrossing;
+
+/**
+ * Determines the possible crossing between any two zones, based on their heights.
+ * Does not require that the zones are joined as only their relative heights are compared.
+ */
+ZoneCrossing Zone_DetermineCrossing(Zone const* from, Zone const* to);
 
 #endif // ZONE_H

--- a/ab3d2_source/hires.s
+++ b/ab3d2_source/hires.s
@@ -61,8 +61,8 @@ PLR_MASTER				equ 'm' ; two player master
 PLR_SLAVE				equ 's' ; two player slave
 PLR_SINGLE				equ 'n' ; Single player
 
-QUIT_KEY				equ RAWKEY_NUM_ASTERISK
-;QUIT_KEY                equ RAWKEY_DOT ; for days when I have no numberpad
+;QUIT_KEY				equ RAWKEY_NUM_ASTERISK
+QUIT_KEY                equ RAWKEY_DOT ; for days when I have no numberpad
 
 ; ZERO-INITIALISED DATA
 				include "bss/system_bss.s"

--- a/ab3d2_source/modules/dev_inst.s
+++ b/ab3d2_source/modules/dev_inst.s
@@ -376,7 +376,7 @@ Dev_PrintStats:
 .dev_ss_stats_pos_vb:
                 dc.b        "X:%5d Z:%5d",0
 .dev_ss_stats_join_vis_vb:
-                dc.b        "JE:%3d/%3d",0
+                dc.b        "JE:%3d/%3d [%04X]",0
 .dev_ss_stats_edge_clips_vb:
                 dc.b        "L:%4d, R:%4d",0
 .dev_bool_off_vb:


### PR DESCRIPTION
Adds a check during the generation of Edge PVS data that checks whether or not two joining zones have any vertical overlap. This is actually needed for a future feature but addresses some overdraw issues now. Although uncommon, there are maps having adjoining zones that are uncrossable, for example the teleport at the end of the chasm in Level F.

Edges found to be uncrossable are removed from the data and treated as solid walls. Compare the screenshots below (UAE) to see the impact where this happens:

Without crossing check:
![Screenshot from 2024-12-09 17-36-45](https://github.com/user-attachments/assets/956040f5-db20-436e-843e-f1747188bc55)

With crossing check:
![Screenshot from 2024-12-09 17-36-59](https://github.com/user-attachments/assets/8b4b2dc0-329f-4646-9cc0-88cea7997700)
