### PR TITLE
Fixed reference to undefined values in 040/060 builds.

### DIFF
--- a/ab3d2_source/hires.s
+++ b/ab3d2_source/hires.s
@@ -61,8 +61,8 @@ PLR_MASTER				equ 'm' ; two player master
 PLR_SLAVE				equ 's' ; two player slave
 PLR_SINGLE				equ 'n' ; Single player
 
-;QUIT_KEY				equ RAWKEY_NUM_ASTERISK
-QUIT_KEY                equ RAWKEY_DOT ; for days when I have no numberpad
+QUIT_KEY				equ RAWKEY_NUM_ASTERISK
+;QUIT_KEY				equ RAWKEY_DOT ; for days when I have no numberpad
 
 
 

--- a/ab3d2_source/modules/c2p/akiko/routines.s
+++ b/ab3d2_source/modules/c2p/akiko/routines.s
@@ -443,6 +443,3 @@ c2p_ConvertSmall1x2OptAkiko:
 
 c2p_AkikoSize_w:
 				dc.w 0
-
-		DCLC C2P_AkikoMirror_b,			dc.b,	0
-		DCLC C2P_AkikoCACR_b,			dc.b,	0

--- a/ab3d2_source/modules/c2p/c2p.s
+++ b/ab3d2_source/modules/c2p/c2p.s
@@ -156,9 +156,10 @@ c2p_ConvertNull:
 c2p_ChunkyOffset_w:			dc.w	0 ; contains the offset into the chunky buffer to start at
 c2p_PlanarOffset_w:			dc.w	0 ; contains the offset into the planar buffer to start at
 
-
-	DCLC C2P_UseAkiko_b
-				dc.b	0	; Preferences Override
+	; These properties are manipulated via C preferences, so keep them in all builds.
+	DCLC C2P_UseAkiko_b,	dc.b,	0
+	DCLC C2P_AkikoMirror_b,	dc.b,	0
+	DCLC C2P_AkikoCACR_b,	dc.b,	0
 
 C2P_NeedsInit_b:
 				dc.b	1	; Options that need the whole C2P to be reinit should set this


### PR DESCRIPTION
Two varialbes defined in conditionally included assembly language (for Akiko settings) referenced from the C preferences handling code. Rather than litter the code with preparser conditionals, just move the two variables so that they are always present.